### PR TITLE
Use relative path for resources

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig(async ({ mode }) => {
 	mkdirSync(resolve('public'), { recursive: true });
 
 	return {
-		base: '/',
+		base: './',
 		plugins: [
 			InjectConfigPlugin(env),
 			react(),


### PR DESCRIPTION
Before this change, VITE would prefix the path to resources with "/".
This doesn't work with tenant based routing ("/id/xyz"), as the frontend
would try to fetch some resources that may differ between tenants
under the root path.
