### PR TITLE
fix: check if authorization response direct post returns non-200 status and throw error if so

### DIFF
--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -177,7 +177,7 @@ export function useOpenID4VP({
 			if (responseData.redirect_uri) {
 				return { url: responseData.redirect_uri };
 			}
-			if (!res.status.toString().startsWith('2')) {
+			if (res.status >= 400) {
 				throw new Error(`Direct post to verifier failed with status ${res.status}`);
 			}
 			showStatusPopup({


### PR DESCRIPTION
Solves #1045 by checking the status code and throwing a new error, which is catched causing the status popup to correctly display the 'failed' status.
