### PR TITLE
fix: send httpProxy requests to backend directly without proxy

### DIFF
--- a/src/lib/services/HttpProxy/HttpProxy.ts
+++ b/src/lib/services/HttpProxy/HttpProxy.ts
@@ -44,6 +44,7 @@ export function useHttpProxy(): IHttpProxy {
 				cacheOnError?: boolean;
 			}
 		): Promise<{ status: number; headers: ResponseHeaders; data: unknown }> {
+			const tenantId = getStoredTenant() || 'default';
 			const useCache = options?.useCache;
 			const cacheOnError = options?.cacheOnError ?? false;
 			const now = Math.floor(Date.now() / 1000);
@@ -108,18 +109,25 @@ export function useHttpProxy(): IHttpProxy {
 			}
 
 			const requestPromise = (async () => {
+				const shouldUseOblivious = obliviousKeyConfig !== null;
+				const targetIsBackend = (new URL(url)).origin === (new URL(BACKEND_URL)).origin;
+
 				try {
 					let response;
-					const shouldUseOblivious = obliviousKeyConfig !== null;
 					if (shouldUseOblivious) {
 						console.log("Using oblivious");
 						const keyConfig = obliviousKeyConfig;
 						if (keyConfig === null) {
 							throw new Error("Oblivious HTTP configuration error");
 						}
+
 						response = await encryptedHttpRequest(OHTTP_RELAY, keyConfig, {
 							method: 'GET',
-							headers,
+							headers: {
+								...headers,
+								// If request target is backend, include tenant id header in proxied request.
+								...(targetIsBackend && { 'X-Tenant-ID': tenantId }),
+							},
 							url,
 						})
 						response.data = response.body;
@@ -164,8 +172,14 @@ export function useHttpProxy(): IHttpProxy {
 								response.data.data = new TextDecoder().decode(response.data.data);
 							}
 						}
+					} else if (targetIsBackend) {
+						response = await axios.get(url, {
+							headers: {
+								Authorization: 'Bearer ' + JSON.parse(sessionStorage.getItem('appToken')!),
+								'X-Tenant-ID': tenantId,
+							},
+						});
 					} else {
-						const tenantId = getStoredTenant() || 'default';
 						response = await axios.post(`${walletBackendServerUrl}/proxy`, {
 							headers,
 							url,
@@ -181,10 +195,11 @@ export function useHttpProxy(): IHttpProxy {
 						);
 					}
 
+					const res = (!shouldUseOblivious && targetIsBackend) ? response : response.data;
 
-					const res = response.data;
-
-					const sourceHeaders = isBinaryRequest ? response.headers : response.data?.headers;
+					const sourceHeaders = (isBinaryRequest || (!shouldUseOblivious && targetIsBackend))
+						? response.headers
+						: response.data?.headers;
 					const contentTypeHeader: string | undefined = sourceHeaders?.['content-type'];
 					const cacheControlHeader: string | undefined = sourceHeaders?.['cache-control'];
 
@@ -300,18 +315,26 @@ export function useHttpProxy(): IHttpProxy {
 			body: any,
 			headers: Record<string, string>
 		): Promise<{ status: number; headers: Record<string, unknown>; data: unknown }> {
+			const tenantId = getStoredTenant() || 'default';
+			const shouldUseOblivious = obliviousKeyConfig !== null;
+			const targetIsBackend = (new URL(url)).origin === (new URL(BACKEND_URL)).origin;
+
 			let response;
 			try {
-				const shouldUseOblivious = obliviousKeyConfig !== null;
 				if (shouldUseOblivious) {
 					console.log("Using oblivious");
 					const keyConfig = obliviousKeyConfig;
 					if (keyConfig === null) {
 						throw new Error("Oblivious HTTP configuration error");
 					}
+
 					response = await encryptedHttpRequest(OHTTP_RELAY, keyConfig, {
 						method: 'POST',
-						headers,
+						headers: {
+							...headers,
+							// If request target is backend, include tenant id header in proxied request.
+							...(targetIsBackend && { 'X-Tenant-ID': tenantId }),
+						},
 						url,
 						body
 					})
@@ -352,8 +375,15 @@ export function useHttpProxy(): IHttpProxy {
 					} else {
 						response.data.data = new TextDecoder().decode(response.data.data);
 					}
+				} else if (targetIsBackend) {
+					response = await axios.post(url, body, {
+						timeout: TIMEOUT,
+						headers: {
+							Authorization: 'Bearer ' + JSON.parse(sessionStorage.getItem('appToken')),
+							'X-Tenant-ID': tenantId,
+						},
+					});
 				} else {
-					const tenantId = getStoredTenant() || 'default';
 					response = await axios.post(`${walletBackendServerUrl}/proxy`, {
 						headers: headers,
 						url: url,
@@ -367,14 +397,26 @@ export function useHttpProxy(): IHttpProxy {
 						}
 					});
 				}
-				return response.data;
+
+				const res = (targetIsBackend && !shouldUseOblivious) ? response : response.data;
+
+				return {
+					status: res.status,
+					headers: res.headers,
+					data: res.data,
+				};
 			} catch (err) {
 				console.log("Post failed");
 				console.log(JSON.stringify(err, Object.getOwnPropertyNames(err)));
+
+				const errRes = (targetIsBackend && !shouldUseOblivious)
+					? err.response
+					: err.response?.data;
+
 				return {
-					data: err.response.data.data,
-					headers: err.response.data.headers,
-					status: err.response.data.status || 500,
+					data: errRes?.data ?? 'POST proxy failed',
+					headers: errRes?.headers ?? {},
+					status: errRes?.status ?? 500,
 				};
 			}
 		},


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
The wallet makes some requests to the backend via the `httpProxy.{post,get}` methods. This PR adds logic to check if the request target is the backend. If that is the case, we skip the proxy and go directly to the target url, except if OHTTP is configured.

We also add `X-Tenant-ID` header to requests going to the backend, directly or via OHTTP.

## Type of change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Changes
- Route requests to the backend via ohttp or make direct requests (don't proxy).
- Add `X-Tenant-ID` header to any request going to backend, via ohttp or directly.
