### PR TITLE
fix: Sync private data without requiring re-authentication (#16)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -336,7 +336,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 						}),
 					);
 					if (updateResp.status === 204) {
-						console.log('syncPrivateData: merged remote and local data successfully');
+						console.debug('syncPrivateData: merged remote and local data successfully');
 						return Ok.EMPTY;
 					}
 				}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -340,7 +340,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 						return Ok.EMPTY;
 					}
 				}
-				console.log('syncPrivateData: merge failed, falling back to re-authentication flow');
+				console.debug('syncPrivateData: merge failed, falling back to re-authentication flow');
 			}
 
 			// Fallback: navigate to sync-fail state for re-authentication

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -324,21 +324,25 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 
 			// Try to merge without re-authentication if keystore is available
 			if (keystore) {
-				const remotePrivateData = getPrivateDataResponse.data.privateData;
-				const mergeResult = await keystore.syncWithRemoteData(remotePrivateData);
-				if (mergeResult.ok) {
-					const newEtag =
-						getPrivateDataResponse.headers?.['x-private-data-etag'] ??
-						getPrivateDataResponse.headers?.['etag'];
-					const updateResp = updatePrivateDataEtag(
-						await post('/user/session/private-data', serializePrivateData(mergeResult.val), {
-							headers: newEtag ? { 'X-Private-Data-If-Match': newEtag } : {},
-						}),
-					);
-					if (updateResp.status === 204) {
-						console.debug('syncPrivateData: merged remote and local data successfully');
-						return Ok.EMPTY;
+				try {
+					const remotePrivateData = getPrivateDataResponse.data.privateData;
+					const mergeResult = await keystore.syncWithRemoteData(remotePrivateData);
+					if (mergeResult.ok) {
+						const newEtag =
+							getPrivateDataResponse.headers?.['x-private-data-etag'] ??
+							getPrivateDataResponse.headers?.['etag'];
+						const updateResp = updatePrivateDataEtag(
+							await post('/user/session/private-data', serializePrivateData(mergeResult.val), {
+								headers: newEtag ? { 'X-Private-Data-If-Match': newEtag } : {},
+							}),
+						);
+						if (updateResp.status === 204) {
+							console.debug('syncPrivateData: merged remote and local data successfully');
+							return Ok.EMPTY;
+						}
 					}
+				} catch (mergeErr) {
+					console.debug('syncPrivateData: silent merge threw, falling back to re-auth', mergeErr);
 				}
 				console.debug('syncPrivateData: merge failed, falling back to re-authentication flow');
 			}
@@ -357,11 +361,15 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 			return Err('syncFailed');
 		}
 		catch (err) {
-			console.error(err);
+			if (typeof err === 'object' && err !== null && 'cause' in err && err.cause === 'x-private-data-etag') {
+				console.debug('syncPrivateData: private data etag conflict', err);
+				return Err('x-private-data-etag');
+			}
+			console.error('syncPrivateData failed', err);
 			return Err('syncFailed');
 		}
 
-	}, [getPrivateDataEtag, get, navigate, isOnline, post, updatePrivateDataEtag, cachedUser]);
+	}, [getPrivateDataEtag, get, navigate, isOnline, post, updatePrivateDataEtag]);
 
 	const updateShowWelcome = useCallback((showWelcome: boolean): void => {
 		if (sessionState) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -327,7 +327,9 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 				const remotePrivateData = getPrivateDataResponse.data.privateData;
 				const mergeResult = await keystore.syncWithRemoteData(remotePrivateData);
 				if (mergeResult.ok) {
-					const newEtag = getPrivateDataResponse.headers?.['etag'];
+					const newEtag =
+						getPrivateDataResponse.headers?.['x-private-data-etag'] ??
+						getPrivateDataResponse.headers?.['etag'];
 					const updateResp = updatePrivateDataEtag(
 						await post('/user/session/private-data', serializePrivateData(mergeResult.val), {
 							headers: newEtag ? { 'X-Private-Data-If-Match': newEtag } : {},

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -348,7 +348,9 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 			queryParams.delete('user');
 			queryParams.delete('sync');
 
-			queryParams.append('user', cachedUser.userHandleB64u);
+			if (cachedUser && cachedUser.userHandleB64u) {
+				queryParams.append('user', cachedUser.userHandleB64u);
+			}
 			queryParams.append('sync', 'fail');
 
 			navigate(`${window.location.pathname}?${queryParams.toString()}`, { replace: true });
@@ -359,7 +361,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 			return Err('syncFailed');
 		}
 
-	}, [getPrivateDataEtag, get, navigate, isOnline, post, updatePrivateDataEtag]);
+	}, [getPrivateDataEtag, get, navigate, isOnline, post, updatePrivateDataEtag, cachedUser]);
 
 	const updateShowWelcome = useCallback((showWelcome: boolean): void => {
 		if (sessionState) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -97,7 +97,8 @@ export interface BackendApi {
 	useClearOnClearSession<T>(storageHandle: UseStorageHandle<T>): UseStorageHandle<T>,
 
 	syncPrivateData(
-		cachedUser: CachedUser | undefined
+		cachedUser: CachedUser | undefined,
+		keystore?: LocalStorageKeystore,
 	): Promise<Result<void,
 		| 'syncFailed'
 		| 'loginKeystoreFailed'
@@ -175,8 +176,8 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		options: { appToken?: string },
 	): { [header: string]: string } => {
 		return {
-			...buildGetHeaders(headers, options),
 			...(getPrivateDataEtag() ? { 'X-Private-Data-If-Match': getPrivateDataEtag() } : {}),
+			...buildGetHeaders(headers, options),
 		};
 	}, [buildGetHeaders, getPrivateDataEtag]);
 
@@ -301,7 +302,8 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 	}, [buildMutationHeaders]);
 
 	const syncPrivateData = useCallback(async (
-		cachedUser: CachedUser | undefined
+		cachedUser: CachedUser | undefined,
+		keystore?: LocalStorageKeystore,
 	): Promise<Result<void,
 		| 'syncFailed'
 		| 'loginKeystoreFailed'
@@ -319,6 +321,27 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 			if (getPrivateDataResponse.status === 304) {
 				return Ok.EMPTY; // already synced
 			}
+
+			// Try to merge without re-authentication if keystore is available
+			if (keystore) {
+				const remotePrivateData = getPrivateDataResponse.data.privateData;
+				const mergeResult = await keystore.syncWithRemoteData(remotePrivateData);
+				if (mergeResult.ok) {
+					const newEtag = getPrivateDataResponse.headers?.['etag'];
+					const updateResp = updatePrivateDataEtag(
+						await post('/user/session/private-data', serializePrivateData(mergeResult.val), {
+							headers: newEtag ? { 'X-Private-Data-If-Match': newEtag } : {},
+						}),
+					);
+					if (updateResp.status === 204) {
+						console.log('syncPrivateData: merged remote and local data successfully');
+						return Ok.EMPTY;
+					}
+				}
+				console.log('syncPrivateData: merge failed, falling back to re-authentication flow');
+			}
+
+			// Fallback: navigate to sync-fail state for re-authentication
 			const queryParams = new URLSearchParams(window.location.search);
 			queryParams.delete('user');
 			queryParams.delete('sync');
@@ -328,15 +351,13 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 
 			navigate(`${window.location.pathname}?${queryParams.toString()}`, { replace: true });
 			return Err('syncFailed');
-			// const privateData = await parsePrivateData(getPrivateDataResponse.data.privateData);
-			// return await loginWebauthn(keystore, promptForPrfRetry, cachedUser);
 		}
 		catch (err) {
 			console.error(err);
 			return Err('syncFailed');
 		}
 
-	}, [getPrivateDataEtag, get, navigate, isOnline]);
+	}, [getPrivateDataEtag, get, navigate, isOnline, post, updatePrivateDataEtag]);
 
 	const updateShowWelcome = useCallback((showWelcome: boolean): void => {
 		if (sessionState) {

--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -75,7 +75,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 
 	useEffect(() => {
 		if (latestIsOnlineStatus === false && isOnline === true && cachedUser) {
-			api.syncPrivateData(cachedUser);
+			api.syncPrivateData(cachedUser, keystore);
 		}
 		if (isLoggedIn) {
 			setLatestIsOnlineStatus(isOnline);
@@ -88,7 +88,8 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		isOnline,
 		latestIsOnlineStatus,
 		setLatestIsOnlineStatus,
-		cachedUser
+		cachedUser,
+		keystore
 	]);
 
 	useEffect(() => {
@@ -98,7 +99,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		const params = new URLSearchParams(location.search);
 		if (synced === false && getCalculatedWalletState() && params.get('sync') !== 'fail') {
 			console.log("Actually syncing...");
-			syncPrivateData(cachedUser).then((r) => {
+			syncPrivateData(cachedUser, keystore).then((r) => {
 				if (!r.ok) {
 					return;
 				}
@@ -108,7 +109,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 			});
 		}
 
-	}, [cachedUser, synced, setSynced, getCalculatedWalletState, syncPrivateData, location.search]);
+	}, [cachedUser, synced, setSynced, getCalculatedWalletState, syncPrivateData, location.search, keystore]);
 
 	useEffect(() => {
 		if (synced === true && window.location.search !== '') {

--- a/src/pages/AddCredentials/AddCredentials.jsx
+++ b/src/pages/AddCredentials/AddCredentials.jsx
@@ -153,7 +153,7 @@ const AddCredentials = () => {
 	}, [api, isOnline, openID4VCIHelper, openID4VCI, filterItemByLang]);
 
 	const handleCredentialConfigurationClick = async (credentialConfigurationIdWithCredentialIssuerIdentifier) => {
-		const result = await api.syncPrivateData(cachedUser);
+		const result = await api.syncPrivateData(cachedUser, keystore);
 		if (!result.ok) {
 			return {};
 		}

--- a/src/pages/Home/Credential.jsx
+++ b/src/pages/Home/Credential.jsx
@@ -82,7 +82,7 @@ const Credential = () => {
 		if (!cachedUser) {
 			return;
 		}
-		const result = await api.syncPrivateData(cachedUser);
+		const result = await api.syncPrivateData(cachedUser, keystore);
 		if (!result.ok) {
 			setLoading(false);
 			return;

--- a/src/pages/SendCredentials/SendCredentials.jsx
+++ b/src/pages/SendCredentials/SendCredentials.jsx
@@ -33,7 +33,7 @@ const SendCredentials = () => {
 		if (!cachedUser) {
 			throw new Error("Could not get cached user");
 		}
-		const result = await api.syncPrivateData(cachedUser);
+		const result = await api.syncPrivateData(cachedUser, keystore);
 		console.log("Result: ", result)
 		if (!result.ok) {
 			throw new Error("PrivateData needs synchronization");

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -877,7 +877,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			setCalculatedWalletState(foldedState);
 
 			return Ok(newPrivateDataEncryptedContainer);
-		} catch {
+		} catch (error) {
+			console.error("Failed to sync with remote data", error);
 			return Err('mergeFailed');
 		}
 	}, [privateData, mainKey, assertKeystoreOpen, writePrivateDataOnIdb, userHandleB64u, setPrivateData, setMainKey, setCalculatedWalletState]);

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -856,26 +856,30 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			return Err('keystoreNotOpen');
 		}
 
-		const remotePrivateData = await keystore.parsePrivateData(remotePrivateDataRaw);
-		const [localPrivateData, localMainKey] = await assertKeystoreOpen();
-		const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(localMainKey, remotePrivateData);
-		const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);
-		const mergedContainer = await mergeEventHistories(remoteContainer, localContainer);
+		try {
+			const remotePrivateData = await keystore.parsePrivateData(remotePrivateDataRaw);
+			const [localPrivateData, localMainKey] = await assertKeystoreOpen();
+			const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(localMainKey, remotePrivateData);
+			const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);
+			const mergedContainer = await mergeEventHistories(remoteContainer, localContainer);
 
-		const { newContainer } = await keystore.updateWalletState([
-			keystore.assertAsymmetricEncryptedContainer(remotePrivateData),
-			remoteMainKey,
-		], mergedContainer as CurrentSchema.WalletStateContainer);
-		const [newPrivateDataEncryptedContainer, newMainKey] = newContainer;
+			const { newContainer } = await keystore.updateWalletState([
+				keystore.assertAsymmetricEncryptedContainer(remotePrivateData),
+				remoteMainKey,
+			], mergedContainer as CurrentSchema.WalletStateContainer);
+			const [newPrivateDataEncryptedContainer, newMainKey] = newContainer;
 
-		await writePrivateDataOnIdb(newPrivateDataEncryptedContainer, userHandleB64u);
-		setPrivateData(newPrivateDataEncryptedContainer);
-		setMainKey(await keystore.exportMainKey(newMainKey));
+			await writePrivateDataOnIdb(newPrivateDataEncryptedContainer, userHandleB64u);
+			setPrivateData(newPrivateDataEncryptedContainer);
+			setMainKey(await keystore.exportMainKey(newMainKey));
 
-		const foldedState = foldState(mergedContainer as CurrentSchema.WalletStateContainer);
-		setCalculatedWalletState(foldedState);
+			const foldedState = foldState(mergedContainer as CurrentSchema.WalletStateContainer);
+			setCalculatedWalletState(foldedState);
 
-		return Ok(newPrivateDataEncryptedContainer);
+			return Ok(newPrivateDataEncryptedContainer);
+		} catch {
+			return Err('mergeFailed');
+		}
 	}, [privateData, mainKey, assertKeystoreOpen, writePrivateDataOnIdb, userHandleB64u, setPrivateData, setMainKey, setCalculatedWalletState]);
 
 	return useMemo(() => ({

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, useMemo } from "react";
 import { useNavigate } from 'react-router-dom';
+import { Err, Ok, Result } from 'ts-results';
 
 import * as config from "../config";
 import { useClearStorages, useLocalStorage, useSessionStorage } from "../hooks/useStorage";
@@ -135,6 +136,12 @@ export interface LocalStorageKeystore {
 		AsymmetricEncryptedContainer,
 		CommitCallback,
 	]>,
+	/**
+	 * Sync with remote private data without requiring re-authentication.
+	 * Uses the existing mainKey to decrypt remote data and merges it with local data.
+	 * @param remotePrivateDataRaw - Raw private data bytes from the server
+	 */
+	syncWithRemoteData(remotePrivateDataRaw: Uint8Array): Promise<Result<AsymmetricEncryptedContainer, 'keystoreNotOpen' | 'mergeFailed'>>,
 }
 
 /** A stateful wrapper around the keystore module, storing state in the browser's localStorage and sessionStorage. */
@@ -844,6 +851,32 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		});
 	}, [editPrivateData, openPrivateData]);
 
+	const syncWithRemoteData = useCallback(async (remotePrivateDataRaw: Uint8Array): Promise<Result<keystore.AsymmetricEncryptedContainer, 'keystoreNotOpen' | 'mergeFailed'>> => {
+		if (!privateData || !mainKey) {
+			return Err('keystoreNotOpen');
+		}
+
+		const remotePrivateData = await keystore.parsePrivateData(remotePrivateDataRaw);
+		const [localPrivateData, localMainKey] = await assertKeystoreOpen();
+		const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(localMainKey, remotePrivateData);
+		const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);
+		const mergedContainer = await mergeEventHistories(remoteContainer, localContainer);
+
+		const { newContainer } = await keystore.updateWalletState([
+			keystore.assertAsymmetricEncryptedContainer(remotePrivateData),
+			remoteMainKey,
+		], mergedContainer as CurrentSchema.WalletStateContainer);
+		const [newPrivateDataEncryptedContainer, newMainKey] = newContainer;
+
+		await writePrivateDataOnIdb(newPrivateDataEncryptedContainer, userHandleB64u);
+		setPrivateData(newPrivateDataEncryptedContainer);
+		setMainKey(await keystore.exportMainKey(newMainKey));
+
+		const foldedState = foldState(mergedContainer as CurrentSchema.WalletStateContainer);
+		setCalculatedWalletState(foldedState);
+
+		return Ok(newPrivateDataEncryptedContainer);
+	}, [privateData, mainKey, assertKeystoreOpen, writePrivateDataOnIdb, userHandleB64u, setPrivateData, setMainKey, setCalculatedWalletState]);
 
 	return useMemo(() => ({
 		isOpen,
@@ -876,6 +909,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		saveCredentialIssuanceSessions,
 		getCredentialIssuanceSessionByState,
 		alterSettings,
+		syncWithRemoteData,
 	}), [
 		isOpen,
 		close,
@@ -907,5 +941,6 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		saveCredentialIssuanceSessions,
 		getCredentialIssuanceSessionByState,
 		alterSettings,
+		syncWithRemoteData,
 	]);
 }


### PR DESCRIPTION
When the server has newer private data (e.g., from another device), merge it with local data directly instead of forcing user re-authentication.

Changes:
- Add syncWithRemoteData() method to LocalStorageKeystore that uses existing mainKey to decrypt remote private data, merges with local data using mergeEventHistories, returns Result instead of null, and lets errors propagate
- Modify syncPrivateData() in api/index.ts to optionally accept keystore
- When keystore is provided, attempt silent merge first
- Pass ETag from GET response as header override to POST
- Flip buildMutationHeaders priority so explicit headers win
- Fall back to SyncPopup re-authentication flow if merge fails
- Update all callers to pass keystore parameter

Fixes sirosfoundation/go-wallet-backend#16. Rebased from wwWallet/wallet-frontend#1018 with review feedback addressed.