### PR TITLE
refactor: tenant should always live on `/id/{tenantId}`

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 // App.jsx
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { Routes, Route, Outlet, useLocation } from 'react-router-dom';
 
 import FadeInContentTransition from './components/Transitions/FadeInContentTransition';
@@ -9,6 +9,7 @@ import Spinner from './components/Shared/Spinner';
 import UpdateNotification from './components/Notifications/UpdateNotification';
 import CredentialDetails from './pages/Home/CredentialDetails';
 import { TenantProvider } from './context/TenantContext';
+import { isMultiTenant } from './lib/tenant';
 
 const lazyWithDelay = (importFunction, delay = 1000) => {
 	return React.lazy(() =>
@@ -37,10 +38,6 @@ const Login = lazyWithDelay(() => import('./pages/Login/Login'), 400);
 const LoginState = lazyWithDelay(() => import('./pages/Login/LoginState'), 400);
 const NotFound = lazyWithDelay(() => import('./pages/NotFound/NotFound'), 400);
 
-/**
- * Protected routes layout - wraps authenticated content with Layout and transitions.
- * Used for both global routes (/) and tenant-scoped routes (/:tenantId/).
- */
 const ProtectedLayout = () => {
 	const location = useLocation();
 	return (
@@ -57,80 +54,72 @@ const ProtectedLayout = () => {
 	);
 };
 
+const PublicLayout = () => {
+	const location = useLocation();
+	return (
+		<FadeInContentTransition reanimateKey={location.pathname}>
+			<Outlet />
+		</FadeInContentTransition>
+	);
+}
+
 /**
  * Authenticated route definitions.
  * Returns an array of Route elements for use in both tenant-scoped and global contexts.
  * Uses relative paths which React Router resolves against the parent route.
  * @param prefix - Optional path prefix ("/" for global routes, "" for nested routes)
  */
-const authenticatedRoutes = (prefix = "") => [
-	<Route key="home" path={`${prefix}` || undefined} index={!prefix} element={<Home />} />,
-	<Route key="settings" path={`${prefix}settings`} element={<Settings />} />,
-	<Route key="credential" path={`${prefix}credential/:batchId`} element={<Credential />} />,
-	<Route key="credential-history" path={`${prefix}credential/:batchId/history`} element={<CredentialHistory />} />,
-	<Route key="credential-details" path={`${prefix}credential/:batchId/details`} element={<CredentialDetails />} />,
-	<Route key="history" path={`${prefix}history`} element={<History />} />,
-	<Route key="pending" path={`${prefix}pending`} element={<Pending />} />,
-	<Route key="history-detail" path={`${prefix}history/:transactionId`} element={<HistoryDetail />} />,
-	<Route key="add" path={`${prefix}add`} element={<AddCredentials />} />,
-	<Route key="send" path={`${prefix}send`} element={<SendCredentials />} />,
-	<Route key="verification" path={`${prefix}verification/result`} element={<VerificationResult />} />,
-	<Route key="cb" path={`${prefix}cb/*`} element={<Home />} />,
+const authenticatedRoutes = [
+	<Route key="home" index element={<Home />} />,
+	<Route key="settings" path="settings" element={<Settings />} />,
+	<Route key="credential" path="credential/:batchId" element={<Credential />} />,
+	<Route key="credential-history" path="credential/:batchId/history" element={<CredentialHistory />} />,
+	<Route key="credential-details" path="credential/:batchId/details" element={<CredentialDetails />} />,
+	<Route key="history" path="history" element={<History />} />,
+	<Route key="pending" path="pending" element={<Pending />} />,
+	<Route key="history-detail" path="history/:transactionId" element={<HistoryDetail />} />,
+	<Route key="add" path="add" element={<AddCredentials />} />,
+	<Route key="send" path="send" element={<SendCredentials />} />,
+	<Route key="verification" path="verification/result" element={<VerificationResult />} />,
+	<Route key="cb" path="cb/*" element={<Home />} />,
+];
+
+/**
+ * Public route definitions.
+ */
+const publicRoutes = [
+	<Route key="login" path="login" element={<Login />} />,
+	<Route key="login-state" path="login-state" element={<LoginState />} />,
+	<Route key="not-found" path="*" element={<NotFound />} />,
 ];
 
 function App() {
-	const location = useLocation();
+	const multiTenant = useMemo(() => isMultiTenant(), []);
+	const routeWrapper = useMemo(
+		() => (multiTenant
+			? <TenantProvider><Outlet /></TenantProvider>
+			: <Outlet />
+		),
+		[multiTenant],
+	);
+	const basePath = useMemo(
+		() => multiTenant ? '/id/:tenantId/*' : '/*',
+		[multiTenant]
+	);
+
 	return (
 		<>
 			<Snowfalling />
 			<Suspense fallback={<Spinner />}>
 				<UpdateNotification />
 				<Routes>
-					{/*
-					 * Tenant-scoped routes (/id/:tenantId/*)
-					 * These routes extract the tenant ID from the URL path and provide it
-					 * via TenantContext. Used for multi-tenant deployments where users
-					 * access the wallet via tenant-specific URLs like /id/acme-corp/login.
-					 *
-					 * URL Structure:
-					 * - Default tenant: /* (backwards compatible root paths)
-					 * - Custom tenants: /id/{tenantId}/* (prefixed paths)
-					 */}
-					<Route path="/id/:tenantId/*" element={<TenantProvider><Outlet /></TenantProvider>}>
-						{/* Tenant-scoped protected routes */}
+					<Route path={basePath} element={routeWrapper}>
 						<Route element={<ProtectedLayout />}>
-							{authenticatedRoutes()}
+							{authenticatedRoutes}
 						</Route>
-						{/* Tenant-scoped public routes */}
-						<Route element={
-							<FadeInContentTransition reanimateKey={location.pathname}>
-								<Outlet />
-							</FadeInContentTransition>
-						}>
-							<Route path="login" element={<Login />} />
-							<Route path="login-state" element={<LoginState />} />
-							<Route path="*" element={<NotFound />} />
+						<Route element={<PublicLayout/>}>
+							{publicRoutes}
 						</Route>
-					</Route>
-
-					{/*
-					 * Global routes (no tenant prefix)
-					 * These routes are used for:
-					 * 1. Single-tenant deployments (backward compatible)
-					 * 2. Global login page where tenant is discovered from passkey
-					 * 3. Returning users who already have passkeys
-					 */}
-					<Route element={<ProtectedLayout />}>
-						{authenticatedRoutes("/")}
-					</Route>
-					<Route element={
-						<FadeInContentTransition reanimateKey={location.pathname}>
-							<Outlet />
-						</FadeInContentTransition>
-					}>
-						<Route path="/login" element={<Login />} />
-						<Route path="/login-state" element={<LoginState />} />
-						<Route path="*" element={<NotFound />} />
 					</Route>
 				</Routes>
 			</Suspense>

--- a/src/components/Auth/PrivateRoute.tsx
+++ b/src/components/Auth/PrivateRoute.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useMemo, useEffect, useState } from 'react';
 import { Navigate, useParams, useLocation } from 'react-router-dom';
 import SessionContext from '@/context/SessionContext';
-import { getStoredTenant, buildTenantRoutePath, isDefaultTenant, TENANT_PATH_PREFIX } from '@/lib/tenant';
+import { getStoredTenant, TENANT_PATH_PREFIX, isMultiTenant, buildTenantRoutePath } from '@/lib/tenant';
 
 const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.ReactElement => {
 	const { isLoggedIn, keystore } = useContext(SessionContext);
@@ -31,7 +31,7 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 
 	// Calculate redirect path for tenant enforcement
 	const tenantRedirectPath = useMemo(() => {
-		if (!isLoggedIn || !storedTenantId) {
+		if (!isLoggedIn || !storedTenantId || !isMultiTenant()) {
 			return null; // No redirect needed for unauthenticated users or no tenant
 		}
 
@@ -52,9 +52,7 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 		}
 
 		// Redirect if URL tenant doesn't match authenticated user's tenant
-		const urlMatchesStored = isDefaultTenant(storedTenantId)
-			? !urlTenantId
-			: urlTenantId === storedTenantId;
+		const urlMatchesStored = urlTenantId === storedTenantId;
 
 		if (!urlMatchesStored) {
 			const correctPath = buildTenantRoutePath(storedTenantId, subPath);
@@ -81,7 +79,7 @@ const PrivateRoute = ({ children }: { children?: React.ReactNode }): React.React
 	// Handle unauthenticated users first
 	if (!isLoggedIn) {
 		// For unauthenticated users, preserve the tenant from URL if present
-		const loginTenantPath = urlTenantId && !isDefaultTenant(urlTenantId)
+		const loginTenantPath = urlTenantId && isMultiTenant()
 			? `/${TENANT_PATH_PREFIX}/${urlTenantId}`
 			: '';
 

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -1,4 +1,4 @@
-import { BRANDING } from '@/config';
+import { BASE_PATH, BRANDING } from '@/config';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -49,7 +49,7 @@ const Logo: React.FC<LogoProps> = ({
 	const img = <img src={logoUrl} alt={alt || t('common.walletName')} className={imgClassName} />
 
 	if (clickable) return (
-		<a href="/" className={aClassName} aria-label={t('common.walletName')}>
+		<a href={BASE_PATH} className={aClassName} aria-label={t('common.walletName')}>
 			{img}
 		</a>
 	);

--- a/src/components/TenantSelector/TenantMeta.tsx
+++ b/src/components/TenantSelector/TenantMeta.tsx
@@ -1,6 +1,6 @@
 import { SyntheticEvent, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { isDefaultTenant, KnownTenant, TENANT_PATH_PREFIX } from "@/lib/tenant";
+import { KnownTenant, TENANT_PATH_PREFIX } from "@/lib/tenant";
 
 export type TenantMetaProps = {
 	knownTenants: KnownTenant[];
@@ -13,7 +13,7 @@ export default function TenantMeta({ knownTenants, tenantId }: TenantMetaProps) 
 	const tenant = useMemo(() => knownTenants.find((t) => t.id === tenantId), [knownTenants, tenantId]);
 
 	const faviconUrl = useMemo(() => {
-			const basePath = isDefaultTenant(tenantId) ? '/' : `/${TENANT_PATH_PREFIX}/${tenantId}/`;
+			const basePath = `/${TENANT_PATH_PREFIX}/${tenantId}/`;
 			return new URL('favicon.ico', window.location.origin + basePath).href;
 	}, [tenantId]);
 

--- a/src/context/StatusContextProvider.tsx
+++ b/src/context/StatusContextProvider.tsx
@@ -17,7 +17,7 @@ function calculateNetworkSpeed(rtt: number): number {
 async function checkInternetConnection(): Promise<{ isConnected: boolean; speed: number }> {
 	try {
 		const startTime = new Date().getTime();
-		const tenantId = getTenantFromUrlPath();
+		const tenantId = getTenantFromUrlPath() || 'default';
 		await axios.get(`${BACKEND_URL}/status`, {
 			timeout: 5000, // Timeout of 5 seconds
 			headers: {

--- a/src/context/TenantContext.tsx
+++ b/src/context/TenantContext.tsx
@@ -2,8 +2,8 @@
  * TenantContext - React context for multi-tenancy support.
  *
  * URL Structure:
- * - Default tenant uses root paths: /, /settings, /login (backwards compatible)
- * - Custom tenants use /id/ prefix: /id/{tenantId}/, /id/{tenantId}/settings
+ * - All tenants use /id/ prefix: /id/{tenantId}/, /id/{tenantId}/settings
+ * - Single-tenant deployments omit the prefix (routes at root)
  *
  * The tenant ID can come from multiple sources (in order of precedence):
  * 1. URL path parameter (/id/:tenantId/*) - for path-based routing
@@ -23,7 +23,7 @@
 
 import React, { createContext, useContext, useEffect, useMemo, useCallback, ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { getStoredTenant, setStoredTenant, clearStoredTenant, buildTenantRoutePath, TENANT_PATH_PREFIX } from '../lib/tenant';
+import { getStoredTenant, setStoredTenant, clearStoredTenant, buildTenantRoutePath, TENANT_PATH_PREFIX, isMultiTenant } from '../lib/tenant';
 
 export interface TenantContextValue {
 	/** Current tenant ID (from URL, prop, or storage) */
@@ -106,7 +106,7 @@ export function TenantProvider({ children, tenantId: propTenantId }: TenantProvi
 	const value = useMemo<TenantContextValue>(() => ({
 		effectiveTenantId,
 		urlTenantId,
-		isMultiTenant: !!effectiveTenantId,
+		isMultiTenant: isMultiTenant(),
 		switchTenant,
 		clearTenant,
 		buildPath,

--- a/src/lib/tenant.test.ts
+++ b/src/lib/tenant.test.ts
@@ -59,12 +59,12 @@ describe('tenant utilities', () => {
 	// Backend discovers tenant from userHandle (login) or tenantId parameter (registration).
 
 	describe('isDefaultTenant', () => {
-		it('should return true for undefined', () => {
-			expect(isDefaultTenant(undefined)).toBe(true);
+		it('should return false for undefined', () => {
+			expect(isDefaultTenant(undefined)).toBe(false);
 		});
 
-		it('should return true for empty string', () => {
-			expect(isDefaultTenant('')).toBe(true);
+		it('should return false for empty string', () => {
+			expect(isDefaultTenant('')).toBe(false);
 		});
 
 		it('should return true for "default"', () => {
@@ -98,24 +98,23 @@ describe('tenant utilities', () => {
 	});
 
 	describe('buildTenantRoutePath', () => {
-		it('should return root path for default tenant', () => {
+		it('should return root path when tenantId is undefined or empty', () => {
 			expect(buildTenantRoutePath(undefined)).toBe('/');
 			expect(buildTenantRoutePath('')).toBe('/');
-			expect(buildTenantRoutePath(DEFAULT_TENANT_ID)).toBe('/');
 		});
 
-		it('should return root subpath for default tenant with subPath', () => {
+		it('should return root subpath when tenantId is undefined', () => {
 			expect(buildTenantRoutePath(undefined, 'settings')).toBe('/settings');
-			expect(buildTenantRoutePath(DEFAULT_TENANT_ID, 'login')).toBe('/login');
-			expect(buildTenantRoutePath('default', '/settings')).toBe('/settings');
 		});
 
-		it('should use /id/ prefix for custom tenants', () => {
+		it('should use /id/ prefix for all tenants including default', () => {
+			expect(buildTenantRoutePath(DEFAULT_TENANT_ID)).toBe(`/${TENANT_PATH_PREFIX}/default/`);
 			expect(buildTenantRoutePath('acme-corp')).toBe(`/${TENANT_PATH_PREFIX}/acme-corp/`);
 			expect(buildTenantRoutePath('my-tenant')).toBe('/id/my-tenant/');
 		});
 
-		it('should use /id/ prefix for custom tenants with subPath', () => {
+		it('should use /id/ prefix for tenants with subPath', () => {
+			expect(buildTenantRoutePath(DEFAULT_TENANT_ID, 'login')).toBe('/id/default/login');
 			expect(buildTenantRoutePath('acme-corp', 'settings')).toBe('/id/acme-corp/settings');
 			expect(buildTenantRoutePath('acme-corp', '/login')).toBe('/id/acme-corp/login');
 		});

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -2,8 +2,7 @@
  * Tenant utilities for multi-tenancy support.
  *
  * URL Structure:
- * - Default tenant uses root paths: /, /settings, /login (backwards compatible)
- * - Custom tenants use /id/ prefix: /id/{tenantId}/, /id/{tenantId}/settings
+ * - Tenants use /id/ prefix: /id/{tenantId}/, /id/{tenantId}/settings
  *
  * Multi-tenancy Design:
  * - Login is global (tenant-discovering): The user selects a passkey, and the tenant
@@ -64,8 +63,8 @@ export const DEFAULT_TENANT_ID = 'default';
 
 /**
  * Tenant names that are reserved and cannot be used for custom tenants.
- * - 'id' - Used as the URL prefix for custom tenants (/id/{tenant}/)
- * - 'default' - Reserved for the default tenant
+ * - 'id' - Used as the URL prefix for tenants (/id/{tenant}/)
+ * - 'default' - Reserved for the system default tenant
  */
 const RESERVED_TENANT_NAMES = new Set(['id', 'default']);
 
@@ -79,17 +78,16 @@ export function isMultiTenant(): boolean {
 
 /**
  * Check if a tenant ID represents the default tenant.
- * Default tenant users should use the root path (/) instead of /id/default/.
  */
 export function isDefaultTenant(tenantId: string | undefined): boolean {
-	return !tenantId || tenantId === DEFAULT_TENANT_ID;
+	return tenantId === DEFAULT_TENANT_ID;
 }
 
 /**
  * Check if a tenant ID matches the URL tenant context.
  */
 export function matchesTenantFromUrl(tenantId: string | undefined, urlTenantId: string | undefined): boolean {
-	return tenantId === urlTenantId || (!urlTenantId && isDefaultTenant(tenantId));
+	return tenantId === urlTenantId;
 }
 
 /**
@@ -101,8 +99,7 @@ export function isReservedTenantName(name: string): boolean {
 
 /**
  * Build the frontend route path for a given tenant.
- * - Default tenant uses root paths: / (backwards compatible)
- * - Custom tenants use /id/{tenantId}/ prefix
+ * - Tenants use /id/{tenantId}/ prefix
  *
  * @param tenantId - The tenant ID
  * @param subPath - Optional path within the tenant (e.g., 'settings')
@@ -111,12 +108,10 @@ export function isReservedTenantName(name: string): boolean {
 export function buildTenantRoutePath(tenantId: string | undefined, subPath?: string): string {
 	const cleanSubPath = subPath?.startsWith('/') ? subPath.slice(1) : (subPath || '');
 
-	// Default tenant uses root paths (backwards compatible)
-	if (isDefaultTenant(tenantId)) {
+	if (!tenantId) {
 		return cleanSubPath ? `/${cleanSubPath}` : '/';
 	}
 
-	// Custom tenants use /id/{tenantId}/ prefix
 	return cleanSubPath
 		? `/${TENANT_PATH_PREFIX}/${tenantId}/${cleanSubPath}`
 		: `/${TENANT_PATH_PREFIX}/${tenantId}/`;
@@ -267,14 +262,13 @@ export function getKnownTenants(
  *
  * URL structure:
  * - /id/{tenantId}/* -> returns tenantId
- * - /* (root paths) -> returns 'default'
  *
  * @returns The tenant ID from URL, or 'default' for root paths
  */
-export function getTenantFromUrlPath(): string {
+export function getTenantFromUrlPath(): string | null {
 	const pathname = window.location.pathname;
 	const match = pathname.match(/^\/id\/([^/]+)/);
-	return match ? match[1] : DEFAULT_TENANT_ID;
+	return match ? match[1] : null;
 }
 
 /**
@@ -288,10 +282,6 @@ export function filterUsersByTenantID(tenantId: string | undefined, users: Cache
 
 		if (userTenantId === undefined) {
 			return true;
-		}
-
-		if (!tenantId) {
-			return isDefaultTenant(userTenantId);
 		}
 
 		return userTenantId === tenantId;

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -16,6 +16,7 @@
  * See go-wallet-backend/docs/adr/011-multi-tenancy.md for full design.
  */
 
+import { BASE_PATH } from "@/config";
 import { type CachedUser } from "@/services/LocalStorageKeystore";
 
 const TENANT_STORAGE_KEY = 'wallet_tenant_id';
@@ -67,6 +68,14 @@ export const DEFAULT_TENANT_ID = 'default';
  * - 'default' - Reserved for the default tenant
  */
 const RESERVED_TENANT_NAMES = new Set(['id', 'default']);
+
+/**
+ * Check if wallet is deployed in a multi-tenancy configuration.
+ */
+export function isMultiTenant(): boolean {
+	const tenantPathRegex = new RegExp(`^/${TENANT_PATH_PREFIX}/[^/]+/?$`);
+	return tenantPathRegex.test(BASE_PATH);
+}
 
 /**
  * Check if a tenant ID represents the default tenant.

--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -5,15 +5,18 @@ import { useTranslation } from 'react-i18next';
 import Button from '../../components/Buttons/Button';
 import { useTenant } from '@/context/TenantContext';
 import { matchesTenantFromUrl } from '@/lib/tenant';
+import { BASE_PATH } from '@/config';
 
 
 const NotFound = () => {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
-	const { buildPath, effectiveTenantId, urlTenantId } = useTenant();
+	const { isMultiTenant, buildPath, effectiveTenantId, urlTenantId } = useTenant();
 
 	const handleBackToHome = () => {
-		if (!matchesTenantFromUrl(effectiveTenantId, urlTenantId)) {
+		if (!isMultiTenant) {
+			navigate(BASE_PATH);
+		} else if (!matchesTenantFromUrl(effectiveTenantId, urlTenantId)) {
 			window.location.href = buildPath();
 		} else {
 			navigate(buildPath());

--- a/vite-plugins/inject-config.ts
+++ b/vite-plugins/inject-config.ts
@@ -48,6 +48,21 @@ export function InjectConfigPlugin(env: Record<string, string>): Plugin {
 					await runInjectConfigFiles();
 				}
 			});
+
+			// Make sure paths resolve in dev server
+			server.middlewares.use((req, res, next) => {
+				if (req.url === '/' && config.BASE_PATH.startsWith('/id/')) {
+					res.writeHead(302, { Location: config.BASE_PATH });
+					res.end();
+					return;
+				}
+
+				if (req.url?.startsWith(config.BASE_PATH) && req.headers['content-type'] !== 'text/html') {
+					req.url = req.url.slice(config.BASE_PATH.length, req.url.length);
+				}
+
+				next();
+			});
 		},
 	};
 }


### PR DESCRIPTION
Refactors tenant routing so all tenants (including default) live under `/id/{tenantId}` instead of serving the default from `/`.

- Added Vite middleware to resolve tenant-scoped asset paths in dev
- New `isMultiTenant()` helper method
- Updated Logo, NotFound, and App.jsx to use dynamic base paths
- Simplified App.jsx with `ProtectedLayout` and `PublicLayout` wrappers