### PR TITLE
feat: AuthZEN trust evaluation for credential issuance and verification (Phase 7)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -67,6 +67,11 @@ export const OPENID4VCI_TRANSACTION_ID_POLLING_INTERVAL_IN_SECONDS = config.open
 export const OPENID4VCI_TRANSACTION_ID_LIFETIME_IN_SECONDS = config.openid4vci_transaction_id_lifetime_in_seconds && !isNaN(parseInt(config.openid4vci_transaction_id_lifetime_in_seconds)) ? parseInt(config.openid4vci_transaction_id_lifetime_in_seconds) : 2592000;
 export const OHTTP_KEY_CONFIG = config.ohttp_key_config;
 export const OHTTP_RELAY = config.ohttp_relay;
+/**
+ * @deprecated AuthZEN is now always enabled. All trust evaluation is delegated to the backend.
+ */
+export const AUTHZEN_ENABLED = true;
+export const AUTHZEN_TENANT_ID = config.authzen_tenant_id || 'default';
 export const VCT_REGISTRY_URL: string | undefined = config.vct_registry_url;
 export const POLICY_LINKS = config.policy_links;
 export const POWERED_BY = config.powered_by;

--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -188,8 +188,23 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 							selectedCredentialConfigurationId,
 							issuer_state,
 							preAuthorizedCode,
-							txCode
+							txCode,
+							trustInfo
 						} = offerData;
+
+						// Check issuer trust before proceeding
+						if (!trustInfo?.trusted) {
+							logger.warn('Untrusted issuer:', credentialIssuer, trustInfo);
+							setTextMessagePopup({
+								title: t('issuance.untrustedIssuer'),
+								description: t('issuance.untrustedIssuerDescription', {
+									issuer: trustInfo?.name || credentialIssuer
+								})
+							});
+							setTypeMessagePopup('error');
+							setMessagePopup(true);
+							return;
+						}
 
 						logger.debug("Handling credential offer...", { credentialIssuer, preAuthorizedCode: !!preAuthorizedCode });
 

--- a/src/lib/interfaces/IOpenID4VCI.ts
+++ b/src/lib/interfaces/IOpenID4VCI.ts
@@ -1,8 +1,15 @@
 import { CredentialConfigurationSupported } from "wallet-common";
-
+import { IssuerTrustResult } from "../services/TrustEvaluator";
 
 export interface IOpenID4VCI {
-	handleCredentialOffer(credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: { inputMode?: string; length?: number; description?: string; }; preAuthorizedCode?: string; }>;
+	handleCredentialOffer(credentialOfferURL: string): Promise<{
+		credentialIssuer: string;
+		selectedCredentialConfigurationId: string;
+		issuer_state?: string;
+		txCode?: { inputMode?: string; length?: number; description?: string; };
+		preAuthorizedCode?: string;
+		trustInfo: IssuerTrustResult;
+	}>;
 	getAvailableCredentialConfigurations(credentialIssuerIdentifier: string): Promise<Record<string, CredentialConfigurationSupported>>;
 	generateAuthorizationRequest(credentialIssuerIdentifier: string, credentialConfigurationId: string, issuer_state?: string): Promise<{ url?: string }>;
 	handleAuthorizationResponse(url: string, dpopNonceHeader?: string): Promise<void>;

--- a/src/lib/interfaces/IOpenID4VP.ts
+++ b/src/lib/interfaces/IOpenID4VP.ts
@@ -1,6 +1,6 @@
 import { ExtendedVcEntity } from "@/context/CredentialsContext";
 import { ParsedTransactionData } from "../services/OpenID4VP/TransactionData/parseTransactionData";
-import type { HandleAuthorizationRequestError } from "wallet-common";
+import type { HandleAuthorizationRequestError, TrustEvaluationResult } from "wallet-common";
 
 export interface IOpenID4VP {
 	handleAuthorizationRequest(
@@ -12,6 +12,7 @@ export interface IOpenID4VP {
 			verifierDomainName: string,
 			verifierPurpose: string,
 			parsedTransactionData: ParsedTransactionData[] | null,
+			trustInfo?: TrustEvaluationResult,
 		}
 		| { error: HandleAuthorizationRequestError }
 	>;

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -13,7 +13,7 @@ import { useCredentialRequest } from './CredentialRequest';
 import { CurrentSchema } from '@/services/WalletStateSchema';
 import SessionContext from '@/context/SessionContext';
 import { useTenant } from '@/context/TenantContext';
-import { CredentialConfigurationSupported, VerifiableCredentialFormat } from 'wallet-common';
+import { CredentialConfigurationSupported, VerifiableCredentialFormat, defaultHttpClient } from 'wallet-common';
 import { useTranslation } from 'react-i18next';
 import CredentialsContext from "@/context/CredentialsContext";
 import { WalletStateUtils } from '@/services/WalletStateUtils';
@@ -25,6 +25,8 @@ import { notify } from "@/context/notifier";
 import { IOpenID4VCIClientStateRepository } from '@/lib/interfaces/IOpenID4VCIClientStateRepository';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/logger';
+import { createIssuerTrustEvaluator, IssuerTrustResult } from '../TrustEvaluator';
+import { BACKEND_URL, AUTHZEN_TENANT_ID } from '../../../config';
 
 type WalletStateCredentialIssuanceSession = CurrentSchema.WalletStateCredentialIssuanceSession;
 
@@ -590,6 +592,14 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 		return {};
 	}, [tokenRequestBuilder, credentialRequest, openID4VCIHelper]);
 
+	// Create issuer trust evaluator
+	const evaluateIssuerTrust = useMemo(() => createIssuerTrustEvaluator({
+		httpClient: defaultHttpClient,
+		backendUrl: BACKEND_URL,
+		getAuthToken: () => JSON.parse(sessionStorage.getItem('appToken') || '""'),
+		tenantId: AUTHZEN_TENANT_ID,
+	}), []);
+
 	/**
  *
  * @param response
@@ -599,7 +609,14 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
  */
 
 	const handleCredentialOffer = useCallback(
-		async (credentialOfferURL: string): Promise<{ credentialIssuer: string, selectedCredentialConfigurationId: string; issuer_state?: string; txCode?: { inputMode?: string; length?: number; description?: string; }; preAuthorizedCode?: string; }> => {
+		async (credentialOfferURL: string): Promise<{
+			credentialIssuer: string;
+			selectedCredentialConfigurationId: string;
+			issuer_state?: string;
+			txCode?: { inputMode?: string; length?: number; description?: string; };
+			preAuthorizedCode?: string;
+			trustInfo: IssuerTrustResult;
+		}> => {
 			const parsedUrl = new URL(credentialOfferURL);
 			let offer;
 			if (parsedUrl.searchParams.get("credential_offer")) {
@@ -626,11 +643,42 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 				throw new Error("Credential configuration not found");
 			}
 
+			// Evaluate issuer trust via AuthZEN
+			// Extract key material from signed_metadata if available
+			let keyMaterial: { type: 'x5c'; key: string[] } | undefined;
+			if (credentialIssuerMetadata.metadata.signed_metadata) {
+				try {
+					const signedMetadataHeader = JSON.parse(
+						new TextDecoder().decode(
+							jose.base64url.decode(credentialIssuerMetadata.metadata.signed_metadata.split('.')[0])
+						)
+					);
+					if (signedMetadataHeader.x5c) {
+						keyMaterial = { type: 'x5c', key: signedMetadataHeader.x5c };
+					}
+				} catch (err) {
+					console.warn('Could not extract x5c from signed_metadata:', err);
+				}
+			}
+
+			const trustInfo = await evaluateIssuerTrust({
+				issuerId: offer.credential_issuer,
+				keyMaterial,
+				context: {
+					credential_configuration_id: selectedConfigurationId,
+				},
+			});
+
+			if (!trustInfo.trusted) {
+				console.warn('Issuer trust evaluation failed for:', offer.credential_issuer);
+				// Return with untrusted status - caller decides how to proceed
+			}
+
 			if (GrantType.PRE_AUTHORIZED_CODE in offer.grants) {
 				const preAuthorizedCodeObject = offer.grants[GrantType.PRE_AUTHORIZED_CODE];
 				const preAuthorizedCode = preAuthorizedCodeObject["pre-authorized_code"];
 				const txCode = preAuthorizedCodeObject["tx_code"];
-				return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, txCode, preAuthorizedCode };
+				return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, txCode, preAuthorizedCode, trustInfo };
 			}
 
 			let issuer_state = undefined;
@@ -638,9 +686,9 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 				issuer_state = offer.grants.authorization_code.issuer_state;
 			}
 
-			return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, issuer_state };
+			return { credentialIssuer: offer.credential_issuer, selectedCredentialConfigurationId: selectedConfigurationId, issuer_state, trustInfo };
 		},
-		[httpProxy, openID4VCIHelper]
+		[httpProxy, openID4VCIHelper, evaluateIssuerTrust]
 	);
 
 	const getAvailableCredentialConfigurations = useCallback(

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -2,8 +2,8 @@ import { IOpenID4VP } from "../../interfaces/IOpenID4VP";
 import {
 	HandleAuthorizationRequestError as HandleAuthorizationRequestErrorType,
 } from "wallet-common";
-import type { OpenID4VPServerCredential } from "wallet-common";
-import { OpenID4VPServerAPI, OpenID4VPResponseMode } from "wallet-common";
+import type { OpenID4VPServerCredential, TrustEvaluationResult } from "wallet-common";
+import { OpenID4VPServerAPI, OpenID4VPResponseMode, defaultHttpClient } from "wallet-common";
 import { OpenID4VPRelyingPartyState } from "../../types/OpenID4VPRelyingPartyState";
 import { useOpenID4VPRelyingPartyStateRepository } from "../OpenID4VPRelyingPartyStateRepository";
 import { useHttpProxy } from "../HttpProxy/HttpProxy";
@@ -16,7 +16,8 @@ import { ExtendedVcEntity } from "@/context/CredentialsContext";
 import { getLeastUsedCredentialInstance } from "../CredentialBatchHelper";
 import { WalletStateUtils } from "@/services/WalletStateUtils";
 import { TransactionDataResponse } from "wallet-common";
-import { verifyRequestUriAndCerts } from "../../utils/verifyRequestUriAndCerts";
+import { createTrustEvaluator } from "../TrustEvaluator";
+import { BACKEND_URL, AUTHZEN_TENANT_ID } from "../../../config";
 import { logger } from '@/logger';
 
 export function useOpenID4VP({
@@ -94,6 +95,14 @@ export function useOpenID4VP({
 			return getLeastUsedCredentialInstance(batchId, vcEntityList, walletState);
 		};
 
+		// Create trust evaluator - all trust evaluation delegated to AuthZEN backend
+		const evaluateTrust = createTrustEvaluator({
+			httpClient: defaultHttpClient,
+			backendUrl: BACKEND_URL,
+			getAuthToken: () => JSON.parse(sessionStorage.getItem('appToken') || '""'),
+			tenantId: AUTHZEN_TENANT_ID,
+		});
+
 		return new OpenID4VPServerAPI<OpenID4VPServerCredential, ParsedTransactionData>({
 			httpClient: { get: httpProxy.get },
 			rpStateStore,
@@ -107,8 +116,8 @@ export function useOpenID4VP({
 			lastUsedNonceStore,
 			parseTransactionData: parseTransactionDataWithUI,
 			transactionDataResponseGenerator: TransactionDataResponse,
-			verifyRequestUriAndCerts: async ({ request_uri, response_uri, parsedHeader }) =>
-				verifyRequestUriAndCerts(request_uri, response_uri, parsedHeader),
+			// All trust evaluation delegated to AuthZEN backend
+			evaluateTrust,
 		});
 	}, [
 		httpProxy.get,
@@ -127,6 +136,7 @@ export function useOpenID4VP({
 			verifierDomainName: string,
 			verifierPurpose: string,
 			parsedTransactionData: ParsedTransactionData[] | null,
+			trustInfo?: TrustEvaluationResult,
 		}
 		| { error: HandleAuthorizationRequestErrorType }
 	> => {

--- a/src/lib/services/TrustEvaluator.ts
+++ b/src/lib/services/TrustEvaluator.ts
@@ -1,9 +1,12 @@
 /**
- * Trust Evaluator adapter for OpenID4VP using AuthZEN client.
+ * Trust Evaluator adapters using AuthZEN client.
  *
  * This module bridges the wallet-common AuthZEN client with the
- * OpenID4VP trust evaluation interface, enabling multi-scheme
- * verifier authentication (did:web, https, x509_san_dns, etc.).
+ * wallet trust evaluation interfaces, enabling trust evaluation for:
+ * - Verifiers (OpenID4VP): did:web, https, x509_san_dns schemes
+ * - Issuers (OpenID4VCI): credential issuer trust evaluation
+ *
+ * All trust decisions are delegated to the AuthZEN backend.
  */
 
 import {
@@ -113,6 +116,136 @@ export function createTrustEvaluator(config: TrustEvaluatorConfig): OpenID4VPTru
 		if (!result.ok) {
 			console.error('Trust evaluation failed:', result.error);
 			// Return untrusted on error
+			return {
+				trusted: false,
+				metadata: { error: result.error },
+			};
+		}
+
+		const trustInfo = result.value;
+
+		return {
+			trusted: trustInfo.status === TrustStatus.TRUSTED,
+			name: trustInfo.name,
+			logo: trustInfo.logo,
+			metadata: trustInfo.metadata,
+		};
+	};
+}
+
+/**
+ * Issuer trust evaluation parameters.
+ */
+export interface IssuerTrustEvaluationParams {
+	/**
+	 * The credential issuer identifier (URL).
+	 */
+	issuerId: string;
+
+	/**
+	 * Key material from the issuer's signed_metadata JWT or certificate.
+	 * If not available, pass undefined and trust evaluation will be based on the issuer ID only.
+	 */
+	keyMaterial?: {
+		type: 'jwk' | 'x5c';
+		key: unknown | unknown[];
+	};
+
+	/**
+	 * Additional context (e.g., credential configuration).
+	 */
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Issuer trust evaluation result.
+ */
+export interface IssuerTrustResult {
+	/**
+	 * Whether the issuer is trusted.
+	 */
+	trusted: boolean;
+
+	/**
+	 * Issuer's display name (from OIDF entity statement or DID document).
+	 */
+	name?: string;
+
+	/**
+	 * Issuer's logo URL.
+	 */
+	logo?: string;
+
+	/**
+	 * Additional metadata from trust evaluation.
+	 */
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * Issuer trust evaluator function type.
+ */
+export type IssuerTrustEvaluator = (params: IssuerTrustEvaluationParams) => Promise<IssuerTrustResult>;
+
+/**
+ * Create an issuer trust evaluator using the AuthZEN client.
+ *
+ * This evaluator calls the wallet backend's /v1/evaluate endpoint
+ * to verify issuer trustworthiness before credential issuance.
+ *
+ * @example
+ * ```typescript
+ * const evaluateIssuer = createIssuerTrustEvaluator({
+ *   httpClient: defaultHttpClient,
+ *   backendUrl: BACKEND_URL,
+ *   getAuthToken: () => sessionStorage.getItem('appToken'),
+ *   tenantId: 'default',
+ * });
+ *
+ * // Check issuer trust before issuance
+ * const result = await evaluateIssuer({
+ *   issuerId: 'https://issuer.example.com',
+ *   keyMaterial: { type: 'x5c', key: x5cChain },
+ * });
+ *
+ * if (!result.trusted) {
+ *   throw new Error('Untrusted issuer');
+ * }
+ * ```
+ */
+export function createIssuerTrustEvaluator(config: TrustEvaluatorConfig): IssuerTrustEvaluator {
+	const clientConfig: AuthZENClientConfig = {
+		httpClient: config.httpClient,
+		baseUrl: config.backendUrl,
+		getAuthToken: config.getAuthToken,
+		tenantId: config.tenantId,
+		timeout: config.timeout,
+	};
+
+	const authzenClient = AuthZENClient(clientConfig);
+
+	return async (params: IssuerTrustEvaluationParams): Promise<IssuerTrustResult> => {
+		const { issuerId, keyMaterial, context } = params;
+
+		// If no key material, use a minimal request with just the issuer ID
+		const authzenKeyMaterial = keyMaterial
+			? {
+				type: keyMaterial.type as 'jwk' | 'x5c',
+				key: keyMaterial.key,
+			}
+			: {
+				type: 'jwk' as const,
+				key: {}, // Empty JWK - trust based on issuer ID resolution only
+			};
+
+		const result = await authzenClient.evaluateIssuer({
+			issuerId,
+			keyMaterial: authzenKeyMaterial,
+			context,
+		});
+
+		if (!result.ok) {
+			console.error('Issuer trust evaluation failed:', result.error);
 			return {
 				trusted: false,
 				metadata: { error: result.error },

--- a/src/lib/services/TrustEvaluator.ts
+++ b/src/lib/services/TrustEvaluator.ts
@@ -1,0 +1,131 @@
+/**
+ * Trust Evaluator adapter for OpenID4VP using AuthZEN client.
+ *
+ * This module bridges the wallet-common AuthZEN client with the
+ * OpenID4VP trust evaluation interface, enabling multi-scheme
+ * verifier authentication (did:web, https, x509_san_dns, etc.).
+ */
+
+import {
+	AuthZENClient,
+	AuthZENClientConfig,
+	TrustStatus,
+	OpenID4VPTrustEvaluator,
+	TrustEvaluationResult,
+	ClientIdScheme,
+	OpenID4VPKeyMaterial,
+} from 'wallet-common';
+import { HttpClient } from 'wallet-common';
+
+/**
+ * Configuration for creating a trust evaluator.
+ */
+export interface TrustEvaluatorConfig {
+	/**
+	 * HTTP client for making requests.
+	 */
+	httpClient: HttpClient;
+
+	/**
+	 * Base URL of the wallet backend (e.g., "https://wallet-backend.example.com").
+	 */
+	backendUrl: string;
+
+	/**
+	 * Function to retrieve the current auth token.
+	 */
+	getAuthToken: () => string | Promise<string>;
+
+	/**
+	 * Tenant ID for multi-tenant backend.
+	 */
+	tenantId: string;
+
+	/**
+	 * Request timeout in milliseconds (default: 30000).
+	 */
+	timeout?: number;
+}
+
+/**
+ * Create an OpenID4VP trust evaluator using the AuthZEN client.
+ *
+ * This evaluator calls the wallet backend's /v1/evaluate endpoint,
+ * which proxies requests to the configured AuthZEN PDP (go-trust service).
+ *
+ * @example
+ * ```typescript
+ * const evaluateTrust = createTrustEvaluator({
+ *   httpClient: defaultHttpClient,
+ *   backendUrl: BACKEND_URL,
+ *   getAuthToken: () => sessionStorage.getItem('appToken'),
+ *   tenantId: 'default',
+ * });
+ *
+ * // Use with OpenID4VPServerAPI
+ * const server = new OpenID4VPServerAPI({
+ *   // ... other deps
+ *   evaluateTrust,
+ * });
+ * ```
+ */
+export function createTrustEvaluator(config: TrustEvaluatorConfig): OpenID4VPTrustEvaluator {
+	const clientConfig: AuthZENClientConfig = {
+		httpClient: config.httpClient,
+		baseUrl: config.backendUrl,
+		getAuthToken: config.getAuthToken,
+		tenantId: config.tenantId,
+		timeout: config.timeout,
+	};
+
+	const authzenClient = AuthZENClient(clientConfig);
+
+	return async (params: {
+		clientIdScheme: ClientIdScheme;
+		keyMaterial: OpenID4VPKeyMaterial;
+		requestUri?: string;
+		responseUri?: string;
+	}): Promise<TrustEvaluationResult> => {
+		const { clientIdScheme, keyMaterial, requestUri, responseUri } = params;
+
+		// Build context with request/response URIs for additional validation
+		const context: Record<string, unknown> = {};
+		if (requestUri) {
+			context.request_uri = requestUri;
+		}
+		if (responseUri) {
+			context.response_uri = responseUri;
+		}
+
+		// Map key material type to AuthZEN format
+		const authzenKeyMaterial = {
+			type: keyMaterial.type as 'jwk' | 'x5c' | 'x509_san_dns',
+			key: keyMaterial.key,
+		};
+
+		// Call the AuthZEN evaluator
+		const result = await authzenClient.evaluateVerifier({
+			clientId: clientIdScheme.clientId,
+			keyMaterial: authzenKeyMaterial,
+			context,
+		});
+
+		if (!result.ok) {
+			console.error('Trust evaluation failed:', result.error);
+			// Return untrusted on error
+			return {
+				trusted: false,
+				metadata: { error: result.error },
+			};
+		}
+
+		const trustInfo = result.value;
+
+		return {
+			trusted: trustInfo.status === TrustStatus.TRUSTED,
+			name: trustInfo.name,
+			logo: trustInfo.logo,
+			metadata: trustInfo.metadata,
+		};
+	};
+}

--- a/src/lib/utils/verifyRequestUriAndCerts.ts
+++ b/src/lib/utils/verifyRequestUriAndCerts.ts
@@ -1,16 +1,23 @@
+/**
+ * @deprecated This module is deprecated. All trust evaluation is now delegated
+ * to the AuthZEN backend via TrustEvaluator.ts. This file is kept for reference
+ * but is no longer used by the OpenID4VP flow.
+ *
+ * @see src/lib/services/TrustEvaluator.ts for the new trust evaluation approach.
+ */
+
 import axios from "axios";
 import { BACKEND_URL, OPENID4VP_SAN_DNS_CHECK_SSL_CERTS, OPENID4VP_SAN_DNS_CHECK } from "../../config";
 import { extractSAN } from "./pki";
 
 /**
- * @deprecated Legacy V1 local certificate verification. In the V2 WebSocket
- * protocol, trust evaluation is performed server-side by the wallet backend
- * (which delegates to an AuthZEN PDP). This function is only used by the V1
- * HTTP proxy code path and will be removed when V1 is retired.
+ * @deprecated Use TrustEvaluator.createTrustEvaluator() instead.
+ * All trust evaluation is now delegated to the AuthZEN backend.
  *
- * Per design: the frontend should never perform its own trust evaluation.
- * Pre-registered entities have pre-computed trust from the admin API;
- * all other entities are evaluated by the backend PDP.
+ * Legacy V1 local certificate verification. In the V2 WebSocket protocol,
+ * trust evaluation is performed server-side by the wallet backend (which
+ * delegates to an AuthZEN PDP). This function is only used by the V1 HTTP
+ * proxy code path and will be removed when V1 is retired.
  */
 export async function verifyRequestUriAndCerts(request_uri: string, response_uri: string, parsedHeader: any) {
 	if (new URL(request_uri).hostname !== new URL(response_uri).hostname) {


### PR DESCRIPTION
## Phase 7: AuthZEN Trust Evaluation

Cherry-picked and rebased from `feature/authzen-trust` onto phase-6/format-handling:
- `a2ec4c2d` — Integrate AuthZEN trust evaluation for OpenID4VP
- `46a1fef9` — Mark verifyRequestUriAndCerts as deprecated
- `31847f77` — Add issuer trust evaluation for OID4VCI

### Changes
- **Trust evaluation**: Integrated AuthZEN PDP for both verifier (OID4VP) and issuer (OID4VCI) trust evaluation
- **TrustEvaluator service**: New `src/lib/services/TrustEvaluator.ts` provides `createTrustEvaluator()` and `createIssuerTrustEvaluator()`
- **Config**: Added `AUTHZEN_TENANT_ID` for multi-tenant PDP routing
- **Deprecation**: Marked `verifyRequestUriAndCerts.ts` as deprecated (x5c validation now server-side)

### Trust Flow
1. OpenID4VP: Verifier trust evaluated via AuthZEN before credential selection popup
2. OpenID4VCI: Issuer trust evaluated during credential offer handling
3. Untrusted entities trigger user-facing error popups

### Architecture
- Frontend no longer performs x5c chain validation directly
- All trust decisions delegated to backend PDP via AuthZEN protocol
- Aligns with security principle: trust evaluation in PDP, not client

### Conflict Resolution
- `OpenID4VP.ts`: Merged logger + TrustEvaluator imports
- `OpenID4VCI.ts`: Combined useTenant context with trust evaluator
- `UriHandlerProvider.tsx`: Integrated trust check into phase-6 async/await pattern
- `verifyRequestUriAndCerts.ts`: Combined deprecation comments

### Testing
- TypeScript compiles clean
- Build passes

**Continues phased `v2-api → release/sirosid` integration:**
- PR #13: Phase 1 (Transport Abstraction)
- PR #14: Phase 2 (Token Refresh)
- PR #15: Phase 3 (P0/P1 + Round 2)
- PR #16: Phase 4 (Trust Types)
- PR #17: Phase 5 (Invite Code + PIN)
- PR #18: Phase 6 (Format Handling)
- **This PR: Phase 7 (AuthZEN Trust)**