### PR TITLE
fix(config): remove TransportType re-export from config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { type ClientMetaConfig } from '../config';
+import type { TransportType } from '@/lib/transport/types/FlowTypes';
 export type DidKeyVersion = "p256-pub" | "jwk_jcs-pub";
 export type LogLevel = "error" | "info" | "warn" | "debug";
 
@@ -132,11 +133,6 @@ export const SHOW_PWA_INSTALL_PROMPT = config.show_pwa_install_prompt === 'true'
 export const POWERED_BY = config.powered_by;
 
 // ===== Transport Configuration =====
-
-// TransportType is defined in @/lib/transport/types/FlowTypes.ts
-// Re-export for backward compatibility
-export type { TransportType } from '@/lib/transport/types/FlowTypes';
-type TransportType = import('@/lib/transport/types/FlowTypes').TransportType;
 
 /**
  * Transport allow-list

--- a/src/config.ts
+++ b/src/config.ts
@@ -136,7 +136,7 @@ export const POWERED_BY = config.powered_by;
 // TransportType is defined in @/lib/transport/types/FlowTypes.ts
 // Re-export for backward compatibility
 export type { TransportType } from '@/lib/transport/types/FlowTypes';
-import type { TransportType } from '@/lib/transport/types/FlowTypes';
+type TransportType = import('@/lib/transport/types/FlowTypes').TransportType;
 
 /**
  * Transport allow-list

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,8 +133,10 @@ export const POWERED_BY = config.powered_by;
 
 // ===== Transport Configuration =====
 
-/** Transport type enumeration */
-export type TransportType = 'http_proxy' | 'websocket' | 'direct';
+// TransportType is defined in @/lib/transport/types/FlowTypes.ts
+// Re-export for backward compatibility
+export type { TransportType } from '@/lib/transport/types/FlowTypes';
+import type { TransportType } from '@/lib/transport/types/FlowTypes';
 
 /**
  * Transport allow-list

--- a/src/context/FlowTransportContext.tsx
+++ b/src/context/FlowTransportContext.tsx
@@ -26,8 +26,8 @@ import {
 	WEBSOCKET_TRANSPORT_ALLOWED,
 	DIRECT_TRANSPORT_ALLOWED,
 	TRANSPORT_PREFERENCE,
-	TransportType,
 } from '@/config';
+import type { TransportType } from '@/lib/transport/types/FlowTypes';
 import { logger } from '@/logger';
 
 // Re-export sign types with WS prefix for clarity

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -11,7 +11,7 @@ import { useCallback, useContext, useState } from 'react';
 import { useFlowTransportSafe } from '@/context/FlowTransportContext';
 import OpenID4VCIContext from '@/context/OpenID4VCIContext';
 import type { OID4VCIFlowResult } from '@/lib/transport/types/OID4VCITypes';
-import type { FlowProgressEvent } from '@/lib/transport/types/FlowTypes';
+import type { FlowProgressEvent, TransportType } from '@/lib/transport/types/FlowTypes';
 
 export interface UseOID4VCIFlowOptions {
 	/** Called when flow progress updates */
@@ -34,7 +34,7 @@ export interface UseOID4VCIFlowReturn {
 	) => Promise<OID4VCIFlowResult>;
 
 	/** Current transport type being used */
-	transportType: 'http_proxy' | 'websocket' | 'direct' | 'none';
+	transportType: TransportType | 'none';
 
 	/** Whether a flow is currently in progress */
 	isLoading: boolean;

--- a/src/hooks/useOID4VPFlow.ts
+++ b/src/hooks/useOID4VPFlow.ts
@@ -15,7 +15,7 @@ import type {
 	OID4VPFlowResult,
 	OID4VPSelectedCredential,
 } from '@/lib/transport/types/OID4VPTypes';
-import type { FlowProgressEvent } from '@/lib/transport/types/FlowTypes';
+import type { FlowProgressEvent, TransportType } from '@/lib/transport/types/FlowTypes';
 
 export interface UseOID4VPFlowOptions {
 	/** Called when flow progress updates */
@@ -36,7 +36,7 @@ export interface UseOID4VPFlowReturn {
 	) => Promise<OID4VPFlowResult>;
 
 	/** Current transport type being used */
-	transportType: 'http_proxy' | 'websocket' | 'direct' | 'none';
+	transportType: TransportType | 'none';
 
 	/** Whether a flow is currently in progress */
 	isLoading: boolean;

--- a/src/lib/transport/types/IFlowTransport.ts
+++ b/src/lib/transport/types/IFlowTransport.ts
@@ -10,9 +10,9 @@
  * - Direct: Browser makes direct CORS requests (future, when ecosystem ready)
  */
 
-import type { FlowRequest, FlowResponse, FlowProgressEvent } from './types/FlowTypes';
-import type { OID4VCIFlowParams, OID4VCIFlowResult } from './types/OID4VCITypes';
-import type { OID4VPFlowParams, OID4VPFlowResult } from './types/OID4VPTypes';
+import type { FlowRequest, FlowResponse, FlowProgressEvent } from './FlowTypes';
+import type { OID4VCIFlowParams, OID4VCIFlowResult } from './OID4VCITypes';
+import type { OID4VPFlowParams, OID4VPFlowResult } from './OID4VPTypes';
 
 /**
  * Transport interface for credential flows


### PR DESCRIPTION
`TransportType` was being re-exported from `src/config.ts` under the guise of backward compatibility, but no consumers import it from there.

- **Removed** `export type { TransportType }` and the inline type alias from `src/config.ts`
- **Added** a top-level `import type { TransportType }` to satisfy the type annotations on `ALLOWED_TRANSPORTS` and `TRANSPORT_PREFERENCE` that remain in the file

`FlowTypes.ts` remains the single source of truth; `config.ts` is now a consumer, not a re-exporter.