### PR TITLE
fix: include logos cache in service worker activate cleanup

### DIFF
--- a/src/context/TenantContext.tsx
+++ b/src/context/TenantContext.tsx
@@ -23,7 +23,7 @@
 
 import React, { createContext, useContext, useEffect, useMemo, useCallback, ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
-import { getStoredTenant, setStoredTenant, clearStoredTenant, buildTenantRoutePath, TENANT_PATH_PREFIX, isMultiTenant } from '../lib/tenant';
+import { getStoredTenant, setStoredTenant, clearStoredTenant, buildTenantRoutePath, TENANT_PATH_PREFIX, isMultiTenant, clearTenantCaches } from '../lib/tenant';
 import { logger } from '../logger';
 
 export interface TenantContextValue {
@@ -33,8 +33,8 @@ export interface TenantContextValue {
 	urlTenantId: string | undefined;
 	/** Whether we're in a tenant-scoped context */
 	isMultiTenant: boolean;
-	/** Switch to a different tenant (navigates to new tenant's home) */
-	switchTenant: (newTenantId: string) => void;
+	/** Switch to a different tenant (navigates to new tenant's home). Clears caches first. */
+	switchTenant: (newTenantId: string) => Promise<void>;
 	/** Clear tenant context (on logout) */
 	clearTenant: () => void;
 	/** Build a tenant-aware path for links and navigation */
@@ -89,7 +89,11 @@ export function TenantProvider({ children, tenantId: propTenantId }: TenantProvi
 		}
 	}, [urlTenantId, storedTenantId]);
 
-	const switchTenant = useCallback((newTenantId: string) => {
+	const switchTenant = useCallback(async (newTenantId: string) => {
+		// Clear tenant-sensitive caches before navigating to ensure fresh content
+		// This prevents the service worker from serving stale tenant logos and config
+		await clearTenantCaches();
+
 		setStoredTenant(newTenantId);
 		// Use full page reload instead of React navigation to ensure tenant-specific
 		// config (potentially in index.html) is loaded fresh
@@ -136,7 +140,7 @@ export function useTenant(): TenantContextValue {
 			effectiveTenantId: storedTenant,
 			urlTenantId,
 			isMultiTenant: false,
-			switchTenant: () => {
+			switchTenant: async () => {
 				logger.warn('switchTenant called outside TenantProvider');
 			},
 			clearTenant: clearStoredTenant,

--- a/src/lib/tenant.test.ts
+++ b/src/lib/tenant.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	extractTenantFromUserHandle,
 	isDefaultTenant,
 	isReservedTenantName,
 	buildTenantRoutePath,
+	clearTenantCaches,
 	DEFAULT_TENANT_ID,
 	TENANT_PATH_PREFIX,
 } from './tenant';
@@ -123,6 +124,61 @@ describe('tenant utilities', () => {
 	describe('TENANT_PATH_PREFIX', () => {
 		it('should be "id"', () => {
 			expect(TENANT_PATH_PREFIX).toBe('id');
+		});
+	});
+
+	describe('clearTenantCaches', () => {
+		const mockCachesKeys = vi.fn();
+		const mockCachesDelete = vi.fn();
+		const originalCaches = globalThis.caches;
+
+		beforeEach(() => {
+			// Mock the Cache API
+			globalThis.caches = {
+				keys: mockCachesKeys,
+				delete: mockCachesDelete,
+			} as unknown as CacheStorage;
+			mockCachesKeys.mockResolvedValue([]);
+			mockCachesDelete.mockResolvedValue(true);
+		});
+
+		afterEach(() => {
+			globalThis.caches = originalCaches;
+			vi.clearAllMocks();
+		});
+
+		it('should clear images and logos caches', async () => {
+			mockCachesKeys.mockResolvedValue(['images', 'logos', 'fonts', 'other-cache']);
+
+			await clearTenantCaches();
+
+			expect(mockCachesDelete).toHaveBeenCalledWith('images');
+			expect(mockCachesDelete).toHaveBeenCalledWith('logos');
+			expect(mockCachesDelete).not.toHaveBeenCalledWith('fonts');
+			expect(mockCachesDelete).not.toHaveBeenCalledWith('other-cache');
+		});
+
+		it('should clear precache when found', async () => {
+			mockCachesKeys.mockResolvedValue(['workbox-precache-v2', 'images']);
+
+			await clearTenantCaches();
+
+			expect(mockCachesDelete).toHaveBeenCalledWith('images');
+			expect(mockCachesDelete).toHaveBeenCalledWith('workbox-precache-v2');
+		});
+
+		it('should not throw when caches is undefined', async () => {
+			globalThis.caches = undefined as unknown as CacheStorage;
+
+			// Should not throw
+			await expect(clearTenantCaches()).resolves.not.toThrow();
+		});
+
+		it('should handle errors gracefully', async () => {
+			mockCachesKeys.mockRejectedValue(new Error('Cache error'));
+
+			// Should not throw, just warn
+			await expect(clearTenantCaches()).resolves.not.toThrow();
 		});
 	});
 });

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -287,3 +287,54 @@ export function filterUsersByTenantID(tenantId: string | undefined, users: Cache
 		return userTenantId === tenantId;
 	});
 }
+
+/**
+ * Cache names used by the service worker that contain tenant-specific content.
+ * These caches should be cleared when switching tenants to ensure fresh content.
+ */
+const TENANT_SENSITIVE_CACHES = ['images', 'logos'];
+
+/**
+ * Clear tenant-sensitive caches when switching tenants.
+ *
+ * This function clears caches that may contain tenant-specific content such as
+ * logos and branding images. It should be called before navigating to a new
+ * tenant URL to ensure the new tenant's assets are fetched fresh.
+ *
+ * The function also unregisters and re-registers the service worker to clear
+ * the precache which contains index.html with tenant-specific config.
+ *
+ * @returns Promise that resolves when caches are cleared
+ */
+export async function clearTenantCaches(): Promise<void> {
+	if (typeof caches === 'undefined') {
+		return; // Cache API not available (e.g., non-HTTPS in some browsers)
+	}
+
+	try {
+		// Clear runtime caches with tenant-specific content
+		const cacheNames = await caches.keys();
+		await Promise.all(
+			cacheNames
+				.filter((name) => TENANT_SENSITIVE_CACHES.includes(name))
+				.map((name) => caches.delete(name))
+		);
+
+		// Signal the service worker to skip waiting and activate immediately
+		// This ensures the precached index.html is not served stale
+		const registration = await navigator.serviceWorker?.getRegistration();
+		if (registration?.waiting) {
+			registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+		}
+
+		// Also clear the workbox precache to force a fresh index.html
+		const precacheName = await caches.keys().then(names =>
+			names.find(name => name.includes('precache'))
+		);
+		if (precacheName) {
+			await caches.delete(precacheName);
+		}
+	} catch (error) {
+		console.warn('Failed to clear tenant caches:', error);
+	}
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -301,8 +301,9 @@ const TENANT_SENSITIVE_CACHES = ['images', 'logos'];
  * logos and branding images. It should be called before navigating to a new
  * tenant URL to ensure the new tenant's assets are fetched fresh.
  *
- * The function also unregisters and re-registers the service worker to clear
- * the precache which contains index.html with tenant-specific config.
+ * It also attempts to activate any waiting service worker immediately and
+ * deletes the Workbox precache so resources such as index.html are fetched
+ * fresh on the next load.
  *
  * @returns Promise that resolves when caches are cleared
  */

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -328,13 +328,13 @@ export async function clearTenantCaches(): Promise<void> {
 			registration.waiting.postMessage({ type: 'SKIP_WAITING' });
 		}
 
-		// Also clear the workbox precache to force a fresh index.html
-		const precacheName = await caches.keys().then(names =>
-			names.find(name => name.includes('precache'))
+		// Also clear all workbox precaches to force a fresh index.html
+		const precacheNames = await caches.keys().then((names) =>
+			names.filter(
+				(name) => name.includes('workbox-precache') || name.includes('precache')
+			)
 		);
-		if (precacheName) {
-			await caches.delete(precacheName);
-		}
+		await Promise.all(precacheNames.map((name) => caches.delete(name)));
 	} catch (error) {
 		console.warn('Failed to clear tenant caches:', error);
 	}

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -4,7 +4,7 @@ import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL, } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
-import { StaleWhileRevalidate, CacheFirst } from "workbox-strategies";
+import { StaleWhileRevalidate, CacheFirst, NetworkFirst } from "workbox-strategies";
 
 const basePath = new URL(self.registration.scope).pathname.replace(/\/?$/, '/') || '/';
 
@@ -12,6 +12,17 @@ clientsClaim();
 
 precacheAndRoute(self.__WB_MANIFEST, {
 	ignoreURLParametersMatching: [/^v$/],
+});
+
+/**
+ * Handle SKIP_WAITING message from client.
+ * This allows the client to force the waiting service worker to activate immediately,
+ * which is needed when switching tenants to ensure fresh precached content.
+ */
+self.addEventListener('message', (event) => {
+	if (event.data && event.data.type === 'SKIP_WAITING') {
+		self.skipWaiting();
+	}
 });
 
 const SPA_ROUTE_ALLOWLIST = [
@@ -44,13 +55,42 @@ registerRoute(
 	createHandlerBoundToURL(`${basePath}index.html`)
 );
 
+/**
+ * Tenant-specific logo files should use NetworkFirst to ensure fresh branding.
+ * This prevents showing stale logos when switching between tenants.
+ */
 registerRoute(
 	({ url }) =>
-		url.pathname.endsWith(".png") ||
+		url.pathname.includes('logo_') ||
+		url.pathname.includes('Logo') ||
+		url.pathname.endsWith('/logo.svg') ||
+		url.pathname.endsWith('/logo.png'),
+	new NetworkFirst({
+		cacheName: "logos",
+		plugins: [
+			new ExpirationPlugin({
+				maxEntries: 20,
+				maxAgeSeconds: 60 * 60, // 1 hour
+			}),
+		],
+	})
+);
+
+/**
+ * Other images use StaleWhileRevalidate for better performance.
+ */
+registerRoute(
+	({ url }) =>
+		(url.pathname.endsWith(".png") ||
 		url.pathname.endsWith(".jpg") ||
 		url.pathname.endsWith(".jpeg") ||
 		url.pathname.endsWith(".svg") ||
-		url.pathname.endsWith(".webp"),
+		url.pathname.endsWith(".webp")) &&
+		// Exclude logos (handled above)
+		!url.pathname.includes('logo_') &&
+		!url.pathname.includes('Logo') &&
+		!url.pathname.endsWith('/logo.svg') &&
+		!url.pathname.endsWith('/logo.png'),
 	new StaleWhileRevalidate({
 		cacheName: "images",
 		plugins: [

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -126,11 +126,11 @@ self.addEventListener("activate", (event) => {
 			// Clean old Workbox precache caches
 			await cleanupOutdatedCaches();
 
-			// Delete runtime image cache
+			// Delete runtime image and logo caches
 			const cacheNames = await caches.keys();
 			await Promise.all(
 				cacheNames
-					.filter((name) => name === "images")
+					.filter((name) => name === "images" || name === "logos")
 					.map((name) => caches.delete(name))
 			);
 


### PR DESCRIPTION
The service worker's `activate` handler cleaned up the `images` runtime cache on each activation, but the newly introduced `logos` cache was omitted — leaving stale logo entries to persist until evicted by `ExpirationPlugin`'s TTL/maxEntries limits rather than being cleared on every SW update.

## Change

- **`src/service-worker.js`** — extend the activate-handler cache filter to include `"logos"` alongside `"images"`:

```js
.filter((name) => name === "images" || name === "logos")
```