### PR TITLE
feat: add client-side credential matching for privacy-preserving OID4VP

### DIFF
--- a/src/context/FlowTransportContext.tsx
+++ b/src/context/FlowTransportContext.tsx
@@ -14,7 +14,7 @@ import type { IFlowTransport } from '@/lib/transport/types/IFlowTransport';
 import { nullTransport } from '@/lib/transport/types/IFlowTransport';
 import { HttpProxyTransport } from '@/lib/transport/HttpProxyTransport';
 import { WebSocketTransport } from '@/lib/transport/WebSocketTransport';
-import type { SignRequestHandler } from '@/lib/transport/WebSocketTransport';
+import type { SignRequestHandler, MatchRequestHandler } from '@/lib/transport/WebSocketTransport';
 import { useHttpProxy } from '@/lib/services/HttpProxy/HttpProxy';
 import {
 	Capabilities,
@@ -30,11 +30,14 @@ import {
 import type { TransportType } from '@/lib/transport/types/FlowTypes';
 import { logger } from '@/logger';
 
-// Re-export sign types with WS prefix for clarity
+// Re-export sign and match types with WS prefix for clarity
 export type {
 	SignRequest as WSSignRequest,
 	SignResponse as WSSignResponse,
 	SignRequestHandler as WSSignRequestHandler,
+	MatchRequest as WSMatchRequest,
+	MatchResponse as WSMatchResponse,
+	MatchRequestHandler as WSMatchRequestHandler,
 } from '@/lib/transport/WebSocketTransport';
 
 /**
@@ -61,6 +64,8 @@ interface FlowTransportContextValue {
 	engineCapabilities: string[];
 	/** Register a sign request handler (for WebSocket) */
 	registerSignHandler: (handler: SignRequestHandler) => () => void;
+	/** Register a match request handler for client-side credential matching (for WebSocket) */
+	registerMatchHandler: (handler: MatchRequestHandler) => () => void;
 }
 
 const FlowTransportContext = createContext<FlowTransportContextValue | null>(null);
@@ -242,6 +247,15 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 		return () => {};
 	}, [wsTransport]);
 
+	// Register match handler on WebSocket transport for client-side credential matching
+	const registerMatchHandler = useCallback((handler: MatchRequestHandler): (() => void) => {
+		if (wsTransport) {
+			return wsTransport.onMatchRequest(handler);
+		}
+		// Return no-op unsubscribe if no WebSocket transport
+		return () => {};
+	}, [wsTransport]);
+
 	const value = useMemo(() => ({
 		transport,
 		transportType,
@@ -253,7 +267,8 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 		capabilitiesLoaded,
 		engineCapabilities,
 		registerSignHandler,
-	}), [transport, transportType, isConnected, reconnect, availableTransports, lastError, clearError, capabilitiesLoaded, engineCapabilities, registerSignHandler]);
+		registerMatchHandler,
+	}), [transport, transportType, isConnected, reconnect, availableTransports, lastError, clearError, capabilitiesLoaded, engineCapabilities, registerSignHandler, registerMatchHandler]);
 
 	return (
 		<FlowTransportContext.Provider value={value}>

--- a/src/hooks/useOID4VPFlow.ts
+++ b/src/hooks/useOID4VPFlow.ts
@@ -8,11 +8,14 @@
  */
 
 import { useCallback, useContext, useEffect, useState } from 'react';
-import { useFlowTransportSafe } from '@/context/FlowTransportContext';
+import {
+	useFlowTransportSafe,
+	type WSMatchRequest as MatchRequest,
+	type WSMatchResponse as MatchResponse,
+} from '@/context/FlowTransportContext';
 import OpenID4VPContext from '@/context/OpenID4VPContext';
 import CredentialsContext, { ExtendedVcEntity } from '@/context/CredentialsContext';
 import { matchCredentials } from '@/services/CredentialMatchingService';
-import type { MatchRequest, MatchResponse } from '@/lib/transport/WebSocketTransport';
 import type {
 	OID4VPFlowResult,
 	OID4VPSelectedCredential,
@@ -93,10 +96,10 @@ export function useOID4VPFlow(options: UseOID4VPFlowOptions = {}): UseOID4VPFlow
 				);
 				return result;
 			} catch (err) {
-				const errMessage = err instanceof Error ? err.message : String(err);
+				console.error('Credential matching failed', err);
 				return {
 					matches: [],
-					no_match_reason: `Matching error: ${errMessage}`,
+					no_match_reason: 'Credential matching failed',
 				};
 			}
 		};

--- a/src/hooks/useOID4VPFlow.ts
+++ b/src/hooks/useOID4VPFlow.ts
@@ -7,10 +7,12 @@
  * Phase 4 of Transport Abstraction
  */
 
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useFlowTransportSafe } from '@/context/FlowTransportContext';
 import OpenID4VPContext from '@/context/OpenID4VPContext';
 import CredentialsContext, { ExtendedVcEntity } from '@/context/CredentialsContext';
+import { matchCredentials } from '@/services/CredentialMatchingService';
+import type { MatchRequest, MatchResponse } from '@/lib/transport/WebSocketTransport';
 import type {
 	OID4VPFlowResult,
 	OID4VPSelectedCredential,
@@ -73,6 +75,35 @@ export function useOID4VPFlow(options: UseOID4VPFlowOptions = {}): UseOID4VPFlow
 		setError(null);
 		transportContext?.clearError?.();
 	}, [transportContext]);
+
+	/**
+	 * Register match handler for client-side credential matching
+	 * This is called when the server requests credential matching for privacy
+	 */
+	useEffect(() => {
+		if (transportType !== 'websocket' || !transportContext?.registerMatchHandler) {
+			return;
+		}
+
+		const handleMatchRequest = async (request: MatchRequest): Promise<MatchResponse> => {
+			try {
+				const result = matchCredentials(
+					vcEntityList || [],
+					request.presentationDefinition
+				);
+				return result;
+			} catch (err) {
+				const errMessage = err instanceof Error ? err.message : String(err);
+				return {
+					matches: [],
+					no_match_reason: `Matching error: ${errMessage}`,
+				};
+			}
+		};
+
+		const unsubscribe = transportContext.registerMatchHandler(handleMatchRequest);
+		return unsubscribe;
+	}, [transportType, transportContext, vcEntityList]);
 
 	/**
 	 * Handle authorization request using the appropriate transport

--- a/src/lib/transport/FlowStateStore.ts
+++ b/src/lib/transport/FlowStateStore.ts
@@ -35,6 +35,7 @@ export type FlowCheckpoint =
 	| 'credential_received'
 	// OID4VP stages
 	| 'request_fetched'
+	| 'client_matching'  // Client-side credential matching for privacy
 	| 'awaiting_selection'
 	| 'selection_made'
 	| 'presentation_submitted'

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -485,10 +485,9 @@ export class WebSocketTransport implements IFlowTransport {
 	}
 
 	/**
-	 * Register a handler for credential match requests from the server.
-	 * When the server needs client-side credential matching (for privacy),
-	 * it sends a match_request with the presentation definition.
-	 * The handler should return matching credential IDs/formats.
+	 * Register a handler for credential match requests initiated by the server.
+	 * The server sends a match_request containing a presentation definition;
+	 * the handler evaluates it against local credentials and returns matching IDs/formats.
 	 */
 	onMatchRequest(handler: MatchRequestHandler): () => void {
 		this.matchHandlers.add(handler);
@@ -616,8 +615,10 @@ export class WebSocketTransport implements IFlowTransport {
 	}
 
 	/**
-	 * Handle a match request from the server
-	 * This is called when the server needs client-side credential matching for privacy
+	 * Handle an incoming match_request from the server.
+	 * The server initiates client-side credential matching by sending a
+	 * presentation definition; the client evaluates it locally and responds
+	 * with the matching credential IDs/formats — credentials never leave the device.
 	 */
 	private async handleMatchRequest(message: ServerMessage): Promise<void> {
 		const flowId = (message.flow_id as string) || (message.flowId as string) || '';
@@ -697,7 +698,7 @@ export class WebSocketTransport implements IFlowTransport {
 		}
 
 		try {
-			this.ws!.send(JSON.stringify(msg));
+			this.ws.send(JSON.stringify(msg));
 		} catch (err) {
 			logger.error('Failed to send match response:', err);
 		}

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -75,6 +75,54 @@ export interface SignResponse {
 export type SignRequestHandler = (request: SignRequest) => Promise<SignResponse>;
 
 /**
+ * Credential match request from server
+ * Sent when server needs client to match credentials locally for privacy
+ */
+export interface MatchRequest {
+	flowId: string;
+	messageId: string;
+	presentationDefinition: {
+		id: string;
+		name?: string;
+		purpose?: string;
+		input_descriptors: Array<{
+			id: string;
+			name?: string;
+			purpose?: string;
+			format?: Record<string, unknown>;
+			constraints?: {
+				limit_disclosure?: 'required' | 'preferred';
+				fields?: Array<{
+					path: string[];
+					filter?: Record<string, unknown>;
+					optional?: boolean;
+				}>;
+			};
+		}>;
+		format?: Record<string, unknown>;
+	};
+}
+
+/**
+ * Credential match response to send back to server
+ */
+export interface MatchResponse {
+	matches: Array<{
+		input_descriptor_id: string;
+		credential_id: string;
+		format: string;
+		vct?: string;
+		available_claims?: string[];
+	}>;
+	no_match_reason?: string;
+}
+
+/**
+ * Match request handler callback type
+ */
+export type MatchRequestHandler = (request: MatchRequest) => Promise<MatchResponse>;
+
+/**
  * Flow action message to send to server
  */
 export interface FlowAction {
@@ -96,6 +144,7 @@ export class WebSocketTransport implements IFlowTransport {
 	private progressCallbacks = new Set<(event: FlowProgressEvent) => void>();
 	private errorCallbacks = new Set<(error: Error) => void>();
 	private signHandlers = new Set<SignRequestHandler>();
+	private matchHandlers = new Set<MatchRequestHandler>();
 
 	private reconnectAttempts = 0;
 	private maxReconnectAttempts = 5;
@@ -457,6 +506,17 @@ export class WebSocketTransport implements IFlowTransport {
 		return () => this.signHandlers.delete(handler);
 	}
 
+	/**
+	 * Register a handler for credential match requests from the server.
+	 * When the server needs client-side credential matching (for privacy),
+	 * it sends a match_request with the presentation definition.
+	 * The handler should return matching credential IDs/formats.
+	 */
+	onMatchRequest(handler: MatchRequestHandler): () => void {
+		this.matchHandlers.add(handler);
+		return () => this.matchHandlers.delete(handler);
+	}
+
 	// ===== Internal Methods =====
 
 	private handleMessage(message: ServerMessage): void {
@@ -479,6 +539,12 @@ export class WebSocketTransport implements IFlowTransport {
 		// Handle sign requests from server
 		if (type === 'sign_request') {
 			this.handleSignRequest(message);
+			return;
+		}
+
+		// Handle match requests from server (privacy-preserving credential matching)
+		if (type === 'match_request' || type === 'match_credentials') {
+			this.handleMatchRequest(message);
 			return;
 		}
 
@@ -568,6 +634,85 @@ export class WebSocketTransport implements IFlowTransport {
 			this.ws!.send(JSON.stringify(msg));
 		} catch (err) {
 			logger.error('Failed to send sign response:', err);
+		}
+	}
+
+	/**
+	 * Handle a match request from the server
+	 * This is called when the server needs client-side credential matching for privacy
+	 */
+	private async handleMatchRequest(message: ServerMessage): Promise<void> {
+		const flowId = (message.flow_id as string) || (message.flowId as string) || '';
+		const request: MatchRequest = {
+			flowId,
+			messageId: (message.message_id as string) || (message.messageId as string) || '',
+			presentationDefinition: (message.presentation_definition as MatchRequest['presentationDefinition'])
+				|| (message.presentationDefinition as MatchRequest['presentationDefinition'])
+				|| { id: '', input_descriptors: [] },
+		};
+
+		if (this.matchHandlers.size === 0) {
+			logger.error('No match handlers registered, cannot respond to match request');
+			this.sendMatchResponse(request.flowId, request.messageId, { matches: [] }, 'No match handler available');
+			return;
+		}
+
+		// Call all handlers until one succeeds
+		let lastError: Error | null = null;
+		for (const handler of this.matchHandlers) {
+			try {
+				const response = await handler(request);
+				this.sendMatchResponse(request.flowId, request.messageId, response);
+				return;
+			} catch (err) {
+				lastError = err instanceof Error ? err : new Error(String(err));
+				logger.warn('Match handler failed:', lastError.message);
+			}
+		}
+
+		// All handlers failed
+		this.sendMatchResponse(
+			request.flowId,
+			request.messageId,
+			{ matches: [] },
+			lastError?.message || 'Credential matching failed'
+		);
+	}
+
+	/**
+	 * Send a match response back to the server
+	 */
+	private sendMatchResponse(
+		flowId: string,
+		messageId: string,
+		response: MatchResponse,
+		error?: string
+	): void {
+		if (!this.isConnected()) {
+			logger.error('Cannot send match response: WebSocket not connected');
+			return;
+		}
+
+		const msg: Record<string, unknown> = {
+			type: 'match_response',
+			flow_id: flowId,
+			message_id: messageId,
+			timestamp: new Date().toISOString(),
+		};
+
+		if (error) {
+			msg.error = error;
+		} else {
+			msg.matches = response.matches;
+			if (response.no_match_reason) {
+				msg.no_match_reason = response.no_match_reason;
+			}
+		}
+
+		try {
+			this.ws!.send(JSON.stringify(msg));
+		} catch (err) {
+			logger.error('Failed to send match response:', err);
 		}
 	}
 

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -21,6 +21,11 @@ import type {
 import type { OID4VCIFlowParams, OID4VCIFlowResult, OID4VCIIssuerInfo } from './types/OID4VCITypes';
 import type { OID4VPFlowParams, OID4VPFlowResult, OID4VPVerifierInfo } from './types/OID4VPTypes';
 import type { TrustStatus } from './types/TrustTypes';
+import type {
+	PresentationDefinition,
+	CredentialMatch,
+	CredentialsMatchedResult,
+} from '@/services/CredentialMatchingService';
 import { logger } from '@/logger';
 
 /**
@@ -81,41 +86,14 @@ export type SignRequestHandler = (request: SignRequest) => Promise<SignResponse>
 export interface MatchRequest {
 	flowId: string;
 	messageId: string;
-	presentationDefinition: {
-		id: string;
-		name?: string;
-		purpose?: string;
-		input_descriptors: Array<{
-			id: string;
-			name?: string;
-			purpose?: string;
-			format?: Record<string, unknown>;
-			constraints?: {
-				limit_disclosure?: 'required' | 'preferred';
-				fields?: Array<{
-					path: string[];
-					filter?: Record<string, unknown>;
-					optional?: boolean;
-				}>;
-			};
-		}>;
-		format?: Record<string, unknown>;
-	};
+	presentationDefinition: PresentationDefinition;
 }
 
 /**
- * Credential match response to send back to server
+ * Credential match response to send back to server.
+ * Re-uses CredentialsMatchedResult shape from CredentialMatchingService.
  */
-export interface MatchResponse {
-	matches: Array<{
-		input_descriptor_id: string;
-		credential_id: string;
-		format: string;
-		vct?: string;
-		available_claims?: string[];
-	}>;
-	no_match_reason?: string;
-}
+export type MatchResponse = CredentialsMatchedResult;
 
 /**
  * Match request handler callback type
@@ -643,12 +621,21 @@ export class WebSocketTransport implements IFlowTransport {
 	 */
 	private async handleMatchRequest(message: ServerMessage): Promise<void> {
 		const flowId = (message.flow_id as string) || (message.flowId as string) || '';
+		const messageId = (message.message_id as string) || (message.messageId as string) || '';
+		const presentationDefinition =
+			(message.presentation_definition as MatchRequest['presentationDefinition'])
+			|| (message.presentationDefinition as MatchRequest['presentationDefinition']);
+
+		if (!presentationDefinition || typeof presentationDefinition !== 'object') {
+			logger.error('Malformed match request: missing required presentation_definition');
+			this.sendMatchResponse(flowId, messageId, { matches: [] }, 'Missing required presentation_definition');
+			return;
+		}
+
 		const request: MatchRequest = {
 			flowId,
-			messageId: (message.message_id as string) || (message.messageId as string) || '',
-			presentationDefinition: (message.presentation_definition as MatchRequest['presentationDefinition'])
-				|| (message.presentationDefinition as MatchRequest['presentationDefinition'])
-				|| { id: '', input_descriptors: [] },
+			messageId,
+			presentationDefinition,
 		};
 
 		if (this.matchHandlers.size === 0) {

--- a/src/lib/transport/__tests__/WebSocketTransport.test.ts
+++ b/src/lib/transport/__tests__/WebSocketTransport.test.ts
@@ -746,6 +746,257 @@ describe('WebSocketTransport', () => {
 		});
 	});
 
+	describe('Match Request/Response', () => {
+		it('should call registered match handler on match_request', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const matchHandler = vi.fn().mockResolvedValue({
+				matches: [
+					{ input_descriptor_id: 'id-1', credential_id: 'cred-1', format: 'vc+sd-jwt' }
+				],
+			});
+			transport.onMatchRequest(matchHandler);
+
+			// Simulate a match_request from the server
+			mockWebSocketInstances[0].simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: {
+					id: 'pd-1',
+					input_descriptors: [{ id: 'id-1', constraints: {} }],
+				},
+			});
+
+			await vi.waitFor(() => {
+				expect(matchHandler).toHaveBeenCalled();
+			});
+
+			expect(matchHandler).toHaveBeenCalledWith(expect.objectContaining({
+				flowId: 'flow-1',
+				messageId: 'msg-1',
+				presentationDefinition: expect.objectContaining({
+					id: 'pd-1',
+				}),
+			}));
+		});
+
+		it('should send match_response with matches from handler', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+			const mockWs = mockWebSocketInstances[0];
+
+			const matchHandler = vi.fn().mockResolvedValue({
+				matches: [
+					{ input_descriptor_id: 'id-1', credential_id: 'cred-1', format: 'vc+sd-jwt', vct: 'Photo' },
+					{ input_descriptor_id: 'id-2', credential_id: 'cred-2', format: 'jwt_vp_json' },
+				],
+			});
+			transport.onMatchRequest(matchHandler);
+
+			// Simulate a match_request
+			mockWs.simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: {
+					id: 'pd-1',
+					input_descriptors: [{ id: 'id-1' }, { id: 'id-2' }],
+				},
+			});
+
+			// Wait for match_response to be sent
+			await vi.waitFor(() => {
+				const matchResponse = mockWs.sentMessages.find(m => {
+					const parsed = JSON.parse(m);
+					return parsed.type === 'match_response';
+				});
+				expect(matchResponse).toBeDefined();
+			});
+
+			const matchResponseMsg = mockWs.sentMessages.find(m =>
+				JSON.parse(m).type === 'match_response'
+			);
+			const parsed = JSON.parse(matchResponseMsg!);
+			expect(parsed.flow_id).toBe('flow-1');
+			expect(parsed.message_id).toBe('msg-1');
+			expect(parsed.matches).toHaveLength(2);
+			expect(parsed.matches[0].input_descriptor_id).toBe('id-1');
+			expect(parsed.matches[0].vct).toBe('Photo');
+		});
+
+		it('should send match_response with no_match_reason', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+			const mockWs = mockWebSocketInstances[0];
+
+			const matchHandler = vi.fn().mockResolvedValue({
+				matches: [],
+				no_match_reason: 'No matching credentials found',
+			});
+			transport.onMatchRequest(matchHandler);
+
+			mockWs.simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			await vi.waitFor(() => {
+				expect(mockWs.sentMessages.some(m =>
+					JSON.parse(m).type === 'match_response'
+				)).toBe(true);
+			});
+
+			const matchResponse = mockWs.sentMessages.find(m =>
+				JSON.parse(m).type === 'match_response'
+			);
+			const parsed = JSON.parse(matchResponse!);
+			expect(parsed.matches).toEqual([]);
+			expect(parsed.no_match_reason).toBe('No matching credentials found');
+		});
+
+		it('should support multiple match handlers', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const handler1 = vi.fn().mockResolvedValue({ matches: [{ input_descriptor_id: 'id-1', credential_id: 'c1', format: 'jwt' }] });
+			const handler2 = vi.fn().mockResolvedValue({ matches: [{ input_descriptor_id: 'id-2', credential_id: 'c2', format: 'jwt' }] });
+
+			transport.onMatchRequest(handler1);
+			transport.onMatchRequest(handler2);
+
+			mockWebSocketInstances[0].simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			await vi.waitFor(() => {
+				expect(handler1).toHaveBeenCalled();
+			});
+
+			// First registered handler should be used (succeeds first)
+			expect(handler1).toHaveBeenCalled();
+		});
+
+		it('should unregister match handler', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const matchHandler = vi.fn().mockResolvedValue({ matches: [] });
+			const unsubscribe = transport.onMatchRequest(matchHandler);
+
+			// Unsubscribe
+			unsubscribe();
+
+			// Simulate a match_request
+			mockWebSocketInstances[0].simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			// Give time for potential async handling
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			// Handler should not be called after unsubscribe
+			expect(matchHandler).not.toHaveBeenCalled();
+		});
+
+		it('should send error in match_response when handler fails', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+			const mockWs = mockWebSocketInstances[0];
+
+			// Register a handler that rejects
+			const matchHandler = vi.fn().mockRejectedValue(new Error('Credential store unavailable'));
+			transport.onMatchRequest(matchHandler);
+
+			// Simulate a match_request
+			mockWs.simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			// Wait for error match_response
+			await vi.waitFor(() => {
+				expect(mockWs.sentMessages.length).toBeGreaterThan(0);
+			});
+
+			await vi.waitFor(() => {
+				const matchResponseMsg = mockWs.sentMessages.find(
+					m => JSON.parse(m).type === 'match_response'
+				);
+				expect(matchResponseMsg).toBeDefined();
+			});
+
+			const matchResponseMsg = mockWs.sentMessages.find(
+				m => JSON.parse(m).type === 'match_response'
+			);
+			const parsed = JSON.parse(matchResponseMsg!);
+			expect(parsed.error).toBeDefined();
+			expect(parsed.error).toContain('Credential store unavailable');
+		});
+
+		it('should handle match_credentials message type as alias', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const matchHandler = vi.fn().mockResolvedValue({ matches: [] });
+			transport.onMatchRequest(matchHandler);
+
+			// Simulate using the alternative message type
+			mockWebSocketInstances[0].simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_credentials',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			await vi.waitFor(() => {
+				expect(matchHandler).toHaveBeenCalled();
+			});
+		});
+
+		it('should send error when no match handlers registered', async () => {
+			const transport = new WebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+			const mockWs = mockWebSocketInstances[0];
+
+			// Don't register any handler
+
+			// Simulate a match_request
+			mockWs.simulateMessage({
+				flowId: 'flow-1',
+				message_id: 'msg-1',
+				type: 'match_request',
+				presentation_definition: { id: 'pd-1', input_descriptors: [] },
+			});
+
+			// Wait for error match_response
+			await vi.waitFor(() => {
+				const matchResponseMsg = mockWs.sentMessages.find(
+					m => JSON.parse(m).type === 'match_response'
+				);
+				expect(matchResponseMsg).toBeDefined();
+			});
+
+			const matchResponseMsg = mockWs.sentMessages.find(
+				m => JSON.parse(m).type === 'match_response'
+			);
+			const parsed = JSON.parse(matchResponseMsg!);
+			expect(parsed.error).toBeDefined();
+			expect(parsed.error).toContain('No match handler available');
+		});
+	});
+
 	describe('Flow Action Sending', () => {
 		it('should send flow_action message with sendFlowAction', async () => {
 			const transport = new WebSocketTransport(wsUrl, authToken);


### PR DESCRIPTION
## Summary

Add WebSocket match request/response handling that enables privacy-preserving credential matching. The server can request client-side matching of credentials against a presentation definition without seeing the actual credentials.

## Changes

### WebSocketTransport.ts
- Add `MatchRequest`, `MatchResponse`, and `MatchRequestHandler` types
- Add `onMatchRequest()` handler registration method
- Add `handleMatchRequest()` to process incoming match requests
- Add `sendMatchResponse()` to send match results back to server
- Handle both `match_request` and `match_credentials` message types

### FlowTransportContext.tsx
- Export match types (`WSMatchRequest`, `WSMatchResponse`, `WSMatchRequestHandler`)
- Add `registerMatchHandler` to context value for handler registration

### useOID4VPFlow.ts
- Import and integrate `CredentialMatchingService.matchCredentials()`
- Register match handler via useEffect when using WebSocket transport
- Handler transforms local credentials against presentation definition

### FlowStateManager.ts
- Add `client_matching` checkpoint for OID4VP flow stages

### Tests
- Add 8 new tests for match request/response handling
- Total: 37 passing tests

## Privacy Benefits

- Credentials remain client-side during matching phase
- Only matching credential IDs/formats are sent to server
- Server never sees full credential content until user consents

## Testing

```bash
npm test -- WebSocketTransport
# 37 tests pass
```

Closes #54