### PR TITLE
fix: vite dev server middleware should not run if BASE_PATH doesn't start with /id/

### DIFF
--- a/vite-plugins/inject-config.ts
+++ b/vite-plugins/inject-config.ts
@@ -51,6 +51,10 @@ export function InjectConfigPlugin(env: Record<string, string>): Plugin {
 
 			// Make sure paths resolve in dev server
 			server.middlewares.use((req, res, next) => {
+				if (!config.BASE_PATH.startsWith('/id/')) {
+					return next();
+				}
+
 				if (req.url === '/' && config.BASE_PATH.startsWith('/id/')) {
 					res.writeHead(302, { Location: config.BASE_PATH });
 					res.end();


### PR DESCRIPTION
## Summary
The Vite dev server has a middleware helper that fixes paths when `BASE_PATH` variable is set to `/id/{...}`. This was causing issues when the `BASE_PATH` was set to `/`.
We fix this by simply exiting early if not specifically in "multi tenant mode".

## Type of change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

