### PR TITLE
ci: security workflow should use node version 22

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run audit


### PR DESCRIPTION
Node v20 is no longer supported, we should at minimum use 22