### PR TITLE
feat: session idle timeout with proactive token refresh

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -116,6 +116,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 	const isOnline = useMemo(() => isOnlineProp === null ? true : isOnlineProp, [isOnlineProp]);
 	const [appToken, setAppToken, clearAppToken] = useSessionStorage<string | null>("appToken", null);
 	const [refreshToken, setRefreshToken, clearRefreshToken] = useSessionStorage<string | null>("refreshToken", null);
+	const [tokenExpiresIn, setTokenExpiresIn, clearTokenExpiresIn] = useSessionStorage<number | null>("tokenExpiresIn", null);
 	const [userHandle,] = useSessionStorage<string | null>("userHandle", null);
 	const [cachedUsers] = useLocalStorage<CachedUser[] | null>("cachedUsers", null);
 	const [sessionState, setSessionState, clearSessionState] = useSessionStorage<SessionState | null>("sessionState", null);
@@ -138,7 +139,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 	}, []);
 
 	const navigate = useNavigate();
-	const clearSessionStorage = useClearStorages(clearAppToken, clearRefreshToken, clearSessionState);
+	const clearSessionStorage = useClearStorages(clearAppToken, clearRefreshToken, clearTokenExpiresIn, clearSessionState);
 
 	// Ref to store current refresh token for the refresh config
 	// This allows the refresh mechanism to access the latest value without stale closures
@@ -169,8 +170,9 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		getRefreshToken: () => refreshTokenRef.current,
 		setAppToken,
 		setRefreshToken,
+		setTokenExpiresIn,
 		clearSession: () => clearSessionRef.current(),
-	}), [setAppToken, setRefreshToken]);
+	}), [setAppToken, setRefreshToken, setTokenExpiresIn]);
 
 	const getAppToken = useCallback((): string | null => {
 		return appToken;
@@ -180,6 +182,42 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		const result = await refreshAccessToken(getTokenRefreshConfig());
 		return result.success;
 	}, [getTokenRefreshConfig]);
+
+	// Proactive token refresh timer: refresh at 80% of token lifetime
+	// to avoid 401s on all transports (HTTP proxy, WebSocket, etc.)
+	const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		// Clear any existing timer
+		if (refreshTimerRef.current) {
+			clearTimeout(refreshTimerRef.current);
+			refreshTimerRef.current = null;
+		}
+
+		// Only set timer if we have a valid session with refresh token and known expiry
+		if (!appToken || !refreshToken || !tokenExpiresIn || tokenExpiresIn <= 0) {
+			return;
+		}
+
+		// Schedule refresh at 80% of token lifetime (e.g., 12 min for 15 min tokens)
+		const refreshDelayMs = tokenExpiresIn * 800; // 80% of expiresIn in ms
+		logger.debug(`Scheduling proactive token refresh in ${Math.round(refreshDelayMs / 1000)}s`);
+
+		refreshTimerRef.current = setTimeout(async () => {
+			logger.debug('Proactive token refresh triggered');
+			const result = await refreshAccessToken(getTokenRefreshConfig());
+			if (!result.success) {
+				logger.warn('Proactive token refresh failed');
+			}
+		}, refreshDelayMs);
+
+		return () => {
+			if (refreshTimerRef.current) {
+				clearTimeout(refreshTimerRef.current);
+				refreshTimerRef.current = null;
+			}
+		};
+	}, [appToken, refreshToken, tokenExpiresIn, getTokenRefreshConfig]);
 
 	function transformResponse(data: any): any {
 		if (data) {
@@ -441,6 +479,10 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		if (response.data.refreshToken) {
 			setRefreshToken(response.data.refreshToken);
 		}
+		// Store token expiry for proactive refresh timer
+		if (response.data.expiresIn) {
+			setTokenExpiresIn(response.data.expiresIn);
+		}
 		setSessionState({
 			uuid: response.data.uuid,
 			displayName: response.data.displayName,
@@ -454,7 +496,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		if (isOnline) {
 			await fetchInitialData(response.data.appToken, response.data.uuid).catch((error) => logger.error('Error in performGetRequests', error));
 		}
-	}, [setAppToken, setRefreshToken, setSessionState, fetchInitialData, isOnline]);
+	}, [setAppToken, setRefreshToken, setTokenExpiresIn, setSessionState, fetchInitialData, isOnline]);
 
 	const updatePrivateData = useCallback(async (
 		newPrivateData: EncryptedContainer,

--- a/src/api/tokenRefresh.ts
+++ b/src/api/tokenRefresh.ts
@@ -20,6 +20,7 @@ export interface RefreshResult {
 	success: boolean;
 	appToken?: string;
 	refreshToken?: string;
+	expiresIn?: number;
 }
 
 export interface TokenRefreshConfig {
@@ -27,6 +28,7 @@ export interface TokenRefreshConfig {
 	getRefreshToken: () => string | null;
 	setAppToken: (token: string) => void;
 	setRefreshToken: (token: string) => void;
+	setTokenExpiresIn?: (expiresIn: number) => void;
 	clearSession: () => void;
 }
 
@@ -83,10 +85,16 @@ async function performRefresh(
 				config.setRefreshToken(response.data.refreshToken);
 			}
 
+			// Update token expiry for proactive refresh timer
+			if (response.data.expiresIn && config.setTokenExpiresIn) {
+				config.setTokenExpiresIn(response.data.expiresIn);
+			}
+
 			return {
 				success: true,
 				appToken: response.data.appToken,
 				refreshToken: response.data.refreshToken,
+				expiresIn: response.data.expiresIn,
 			};
 		}
 

--- a/src/context/FlowTransportContext.tsx
+++ b/src/context/FlowTransportContext.tsx
@@ -71,6 +71,8 @@ interface FlowTransportProviderProps {
 	authToken: string | null;
 	/** Tenant ID for multi-tenant routing */
 	tenantId: string;
+	/** Callback to refresh the access token before reconnect. Returns the new token or null on failure. */
+	onRefreshToken?: () => Promise<string | null>;
 }
 
 /**
@@ -79,7 +81,8 @@ interface FlowTransportProviderProps {
 export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 	children,
 	authToken,
-	tenantId
+	tenantId,
+	onRefreshToken
 }) => {
 	const httpProxy = useHttpProxy();
 
@@ -215,9 +218,20 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 		return { transport: nullTransport, transportType: 'none' as const };
 	}, [availableTransports, wsTransport, isConnected, httpTransport]);
 
-	// Reconnect function for WebSocket
+	// Reconnect function for WebSocket — refreshes token first if available
 	const reconnect = useCallback(async () => {
 		if (wsTransport && WEBSOCKET_TRANSPORT_ALLOWED) {
+			// Refresh access token before reconnect to avoid sending an expired token
+			if (onRefreshToken) {
+				const newToken = await onRefreshToken();
+				if (newToken) {
+					wsTransport.updateAuthToken(newToken, tenantId);
+				} else {
+					const err = new Error('Token refresh failed before reconnect');
+					setLastError(err);
+					throw err;
+				}
+			}
 			try {
 				await wsTransport.connect();
 				setIsConnected(true);
@@ -227,7 +241,7 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 				throw error;
 			}
 		}
-	}, [wsTransport]);
+	}, [wsTransport, onRefreshToken, tenantId]);
 
 	const clearError = useCallback(() => {
 		setLastError(null);

--- a/src/context/FlowTransportProviderWrapper.tsx
+++ b/src/context/FlowTransportProviderWrapper.tsx
@@ -8,8 +8,9 @@
  * Phase 5 of Transport Abstraction
  */
 
-import React from 'react';
+import React, { useCallback, useContext } from 'react';
 import { FlowTransportProvider } from './FlowTransportContext';
+import SessionContext from './SessionContext';
 import { useSessionStorage } from '@/hooks/useStorage';
 import { getTenantFromUrlPath } from '@/lib/tenant';
 
@@ -32,8 +33,18 @@ export const FlowTransportProviderWrapper: React.FC<FlowTransportProviderWrapper
 	// URL structure: /id/{tenantId}/* -> returns tenantId, or 'default' for root paths
 	const tenantId = getTenantFromUrlPath() ?? 'default';
 
+	// Use the api from SessionContext to refresh tokens before WS reconnect
+	const { api } = useContext(SessionContext);
+	const handleRefreshToken = useCallback(async (): Promise<string | null> => {
+		const success = await api.refreshAccessToken();
+		if (success) {
+			return api.getAppToken();
+		}
+		return null;
+	}, [api]);
+
 	return (
-		<FlowTransportProvider authToken={appToken} tenantId={tenantId}>
+		<FlowTransportProvider authToken={appToken} tenantId={tenantId} onRefreshToken={handleRefreshToken}>
 			{children}
 		</FlowTransportProvider>
 	);


### PR DESCRIPTION
## Summary

Implements proactive session idle timeout for the frontend (ref: issue #97).  
Companion to go-wallet-backend PR sirosfoundation/go-wallet-backend#101.

## Changes

### Proactive token refresh timer (`src/api/index.ts`)
- Store `expiresIn` from login/signup/refresh responses in sessionStorage
- Schedule a refresh at 80% of TTL so tokens are replaced before they expire
- Timer resets on every successful refresh

### Token refresh infrastructure (`src/api/tokenRefresh.ts`)
- `RefreshResult` now includes `expiresIn`
- `TokenRefreshConfig` gains `setTokenExpiresIn` callback so the refresh path can update the stored TTL

### WebSocket reconnect with token refresh (`src/context/FlowTransportContext.tsx`)
- New `onRefreshToken` prop on `FlowTransportProvider`
- On WS disconnect/reconnect, calls `onRefreshToken()` to obtain a fresh access token **before** re-establishing the WebSocket connection
- Updates the WS transport's auth token with the refreshed value
- Critical for deployments where the HTTP proxy transport is disabled

### Wrapper wiring (`src/context/FlowTransportProviderWrapper.tsx`)
- Wires `onRefreshToken` using `SessionContext.api.refreshAccessToken()` and `getAppToken()`

## Testing

- TypeScript compilation passes (no new errors)
- All pre-existing TS errors are unrelated (OIDC gate, mdoc, worker types)