### PR TITLE
feat: add script to generate nginx security headers from environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,3 +38,8 @@ SHOW_PWA_INSTALL_PROMPT=false
 # Used to generate well-known files at startup
 WELLKNOWN_APPLE_APPIDS=""
 WELLKNOWN_ANDROID_PACKAGE_NAMES_AND_FINGERPRINTS=""
+
+# Variables used by nginx-security-headers-config.sh helper
+NGINX_SEC_HEADER_FILE=""
+NGINX_CSP_ENFORCE_RESOURCE_HTTPS=""
+NGINX_ENABLE_HSTS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV NODE_PATH=/usr/local/lib/node_modules
 WORKDIR /usr/share/nginx/
 
 COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
-COPY ./nginx/docker-entrypoint.d/wallet-config.sh /docker-entrypoint.d/wallet-config.sh
+COPY ./nginx/docker-entrypoint.d/ /docker-entrypoint.d/
 COPY ./utils/create_custom_branding_resources.sh /home/node/app/
 
 COPY --from=builder --chown=nginx:nginx /home/node/app/dist/ ./html/

--- a/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
+++ b/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
@@ -2,15 +2,20 @@
 set -e
 
 # Available options from environment variables:
+# - OUTPUT_FILE (Default: "/etc/nginx/conf.d/security-headers.conf")
 # - WS_URL
 # - WALLET_BACKEND_URL
 # - OHTTP_KEY_CONFIG
 # - OHTTP_RELAY
 # - VCT_REGISTRY_URL
+# - ENFORCE_RESOURCE_HTTPS ("true" or "false". Default: "false")
+# - ENABLE_HSTS ("true" or "false". Default: "false")
 
 # -------------------------------------------------------------------------------------------------
-OUTPUT_FILE="/etc/nginx/conf.d/security-headers.conf"
-#
+if [ -z "${OUTPUT_FILE}" ]; then
+	OUTPUT_FILE="/etc/nginx/conf.d/security-headers.conf"
+fi
+
 CONNECT_SRC="'self'"
 
 # -------------------------------------------------------------------------------------------------
@@ -34,13 +39,19 @@ if [ -n "${VCT_REGISTRY_URL}" ]; then
 	CONNECT_SRC="${CONNECT_SRC} ${VCT_REGISTRY_URL}"
 fi
 
+if [ "${ENFORCE_RESOURCE_HTTPS}" = "true" ]; then
+	RESOURCE_SCHEME_SRC="https:"
+else
+	RESOURCE_SCHEME_SRC="https: http:"
+fi
+
 # -------------------------------------------------------------------------------------------------
 # Content Security Policy configuration
 CSP="default-src 'self'; \
 script-src 'self'; \
 style-src 'self'; \
 font-src 'self' data:; \
-img-src 'self' data: https:; \
+img-src 'self' data: ${RESOURCE_SCHEME_SRC}; \
 connect-src ${CONNECT_SRC}; \
 frame-ancestors 'none'; \
 base-uri 'self'; \
@@ -52,7 +63,15 @@ add_header Content-Security-Policy "${CSP}" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header X-Permitted-Cross-Domain-Policies "none" always;
+add_header Permissions-Policy "microphone=(), geolocation=(), payment=()" always;
 EOF
+
+# -------------------------------------------------------------------------------------------------
+if [ "${ENABLE_HSTS}" = "true" ]; then
+	RESOURCE_SCHEME_SRC="https:"
+	echo 'add_header Strict-Transport-Security "max-age=63072000" always;' >> "${OUTPUT_FILE}"
+fi
 
 # -------------------------------------------------------------------------------------------------
 echo "Generated security headers: ${OUTPUT_FILE}"

--- a/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
+++ b/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
@@ -2,18 +2,18 @@
 set -e
 
 # Available options from environment variables:
-# - OUTPUT_FILE (Default: "/etc/nginx/conf.d/security-headers.conf")
+# - NGINX_SEC_HEADER_FILE (Default: "/etc/nginx/conf.d/security-headers.conf")
 # - WS_URL
 # - WALLET_BACKEND_URL
 # - OHTTP_KEY_CONFIG
 # - OHTTP_RELAY
 # - VCT_REGISTRY_URL
-# - ENFORCE_RESOURCE_HTTPS ("true" or "false". Default: "false")
-# - ENABLE_HSTS ("true" or "false". Default: "false")
+# - NGINX_CSP_ENFORCE_RESOURCE_HTTPS ("true" or "false". Default: "false")
+# - NGINX_ENABLE_HSTS ("true" or "false". Default: "false")
 
 # -------------------------------------------------------------------------------------------------
-if [ -z "${OUTPUT_FILE}" ]; then
-	OUTPUT_FILE="/etc/nginx/conf.d/security-headers.conf"
+if [ -z "${NGINX_SEC_HEADER_FILE}" ]; then
+	NGINX_SEC_HEADER_FILE="/etc/nginx/conf.d/security-headers.conf"
 fi
 
 CONNECT_SRC="'self'"
@@ -39,7 +39,7 @@ if [ -n "${VCT_REGISTRY_URL}" ]; then
 	CONNECT_SRC="${CONNECT_SRC} ${VCT_REGISTRY_URL}"
 fi
 
-if [ "${ENFORCE_RESOURCE_HTTPS}" = "true" ]; then
+if [ "${NGINX_CSP_ENFORCE_RESOURCE_HTTPS}" = "true" ]; then
 	RESOURCE_SCHEME_SRC="https:"
 else
 	RESOURCE_SCHEME_SRC="https: http:"
@@ -58,7 +58,7 @@ base-uri 'self'; \
 form-action 'self'"
 
 # -------------------------------------------------------------------------------------------------
-cat > "${OUTPUT_FILE}" <<EOF
+cat > "${NGINX_SEC_HEADER_FILE}" <<EOF
 add_header Content-Security-Policy "${CSP}" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header X-Frame-Options "DENY" always;
@@ -68,10 +68,9 @@ add_header Permissions-Policy "microphone=(), geolocation=(), payment=()" always
 EOF
 
 # -------------------------------------------------------------------------------------------------
-if [ "${ENABLE_HSTS}" = "true" ]; then
-	RESOURCE_SCHEME_SRC="https:"
-	echo 'add_header Strict-Transport-Security "max-age=63072000" always;' >> "${OUTPUT_FILE}"
+if [ "${NGINX_ENABLE_HSTS}" = "true" ]; then
+	echo 'add_header Strict-Transport-Security "max-age=63072000" always;' >> "${NGINX_SEC_HEADER_FILE}"
 fi
 
 # -------------------------------------------------------------------------------------------------
-echo "Generated security headers: ${OUTPUT_FILE}"
+echo "Generated security headers: ${NGINX_SEC_HEADER_FILE}"

--- a/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
+++ b/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
@@ -39,7 +39,7 @@ fi
 CSP="default-src 'self'; \
 script-src 'self'; \
 style-src 'self'; \
-font-src 'self' data: https:; \
+font-src 'self' data:; \
 img-src 'self' data: https:; \
 connect-src ${CONNECT_SRC}; \
 frame-ancestors 'none'; \

--- a/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
+++ b/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -e
+
+# Available options from environment variables:
+# - WS_URL
+# - WALLET_BACKEND_URL
+# - OHTTP_KEY_CONFIG
+# - OHTTP_RELAY
+# - VCT_REGISTRY_URL
+
+# -------------------------------------------------------------------------------------------------
+OUTPUT_FILE="/etc/nginx/conf.d/security-headers.conf"
+#
+CONNECT_SRC="'self'"
+
+# -------------------------------------------------------------------------------------------------
+if [ -n "${WS_URL}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${WS_URL}"
+fi
+
+if [ -n "${WALLET_BACKEND_URL}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${WALLET_BACKEND_URL}"
+fi
+
+if [ -n "${OHTTP_KEY_CONFIG}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${OHTTP_KEY_CONFIG}"
+fi
+
+if [ -n "${OHTTP_RELAY}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${OHTTP_RELAY}"
+fi
+
+if [ -n "${VCT_REGISTRY_URL}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${VCT_REGISTRY_URL}"
+fi
+
+# -------------------------------------------------------------------------------------------------
+# Content Security Policy configuration
+CSP="default-src 'self'; \
+script-src 'self'; \
+style-src 'self'; \
+font-src 'self' data: https:; \
+img-src 'self' data: https:; \
+connect-src ${CONNECT_SRC}; \
+frame-ancestors 'none'; \
+base-uri 'self'; \
+form-action 'self'"
+
+# -------------------------------------------------------------------------------------------------
+cat > "${OUTPUT_FILE}" <<EOF
+add_header Content-Security-Policy "${CSP}" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+EOF
+
+# -------------------------------------------------------------------------------------------------
+echo "Generated security headers: ${OUTPUT_FILE}"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,8 @@
 server {
     listen 80;
 
+    include /etc/nginx/conf.d/security-headers*.conf;
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html;

--- a/package.json
+++ b/package.json
@@ -71,12 +71,14 @@
     "eslint": "^8.56.0",
     "eslint-config-react-app": "^7.0.1",
     "jsdom": "^28.0.0",
+    "patch-package": "^8.0.1",
     "vite": "^6.1.0",
     "vite-plugin-checker": "^0.11.0",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^1.5.0"
   },
   "scripts": {
+    "postinstall": "patch-package",
     "start": "vite --no-open",
     "start-docker": "npx vite --no-open",
     "build": "vite build",

--- a/patches/cbor-x+1.6.0.patch
+++ b/patches/cbor-x+1.6.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/cbor-x/decode.js b/node_modules/cbor-x/decode.js
+index 362ff36..0558dcd 100644
+--- a/node_modules/cbor-x/decode.js
++++ b/node_modules/cbor-x/decode.js
+@@ -44,7 +44,7 @@ let inlineObjectReadThreshold = 2;
+ var BlockedFunction // we use search and replace to change the next call to BlockedFunction to avoid CSP issues for
+ // no-eval build
+ try {
+-	new Function('')
++	new BlockedFunction('')
+ } catch(error) {
+ 	// if eval variants are not supported, do not create inline object readers ever
+ 	inlineObjectReadThreshold = Infinity

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,6 +2829,11 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.13.tgz#87b309a6379c22b926e696893237826f64339b6f"
   integrity sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zxing/text-encoding@0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
@@ -3243,7 +3248,7 @@ cac@^6.7.14:
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
-call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
@@ -3268,6 +3273,14 @@ call-bound@^1.0.2, call-bound@^1.0.3:
   dependencies:
     call-bind-apply-helpers "^1.0.1"
     get-intrinsic "^1.2.6"
+
+call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsite@^1.0.0:
   version "1.0.0"
@@ -3328,7 +3341,7 @@ chai@^4.3.10:
     pathval "^1.1.1"
     type-detect "^4.1.0"
 
-chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0:
+chalk@4.1.2, chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3357,6 +3370,11 @@ chokidar@^4.0.3:
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 classnames@2.3.1:
   version "2.3.1"
@@ -3927,7 +3945,7 @@ es-iterator-helpers@^1.2.1:
     iterator.prototype "^1.1.4"
     safe-array-concat "^1.1.3"
 
-es-object-atoms@^1.0.0:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
@@ -4397,6 +4415,13 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 findup-sync@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-5.0.0.tgz#54380ad965a7edca00cc8f63113559aadc541bd2"
@@ -4454,6 +4479,15 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     mime-types "^2.1.12"
+
+fs-extra@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-extra@^9.0.1:
   version "9.1.0"
@@ -4523,6 +4557,22 @@ get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@
     es-object-atoms "^1.0.0"
     function-bind "^1.1.2"
     get-proto "^1.0.0"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
     gopd "^1.2.0"
     has-symbols "^1.1.0"
     hasown "^2.0.2"
@@ -4638,7 +4688,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -4882,6 +4932,11 @@ is-date-object@^1.0.5, is-date-object@^1.1.0:
     call-bound "^1.0.2"
     has-tostringtag "^1.0.2"
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -5040,6 +5095,13 @@ is-windows@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -5183,6 +5245,17 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stable-stringify@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -5203,6 +5276,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonpointer@^5.0.0, jsonpointer@^5.0.1:
   version "5.0.1"
@@ -5242,6 +5320,13 @@ keyv@^4.5.3:
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 language-subtag-registry@^0.3.20:
   version "0.3.23"
@@ -5485,7 +5570,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4, micromatch@^4.0.8:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -5724,6 +5809,14 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -5806,6 +5899,26 @@ parse5@^8.0.0:
   integrity sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==
   dependencies:
     entities "^6.0.0"
+
+patch-package@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.1.tgz#79d02f953f711e06d1f8949c8a13e5d3d7ba1a60"
+  integrity sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^10.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.2.4"
+    yaml "^2.2.2"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6442,6 +6555,11 @@ semver@^7.3.7, semver@^7.5.4:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
+semver@^7.5.3:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
 semver@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
@@ -6590,6 +6708,11 @@ signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -6927,6 +7050,11 @@ tldts@^7.0.5:
   integrity sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==
   dependencies:
     tldts-core "^7.0.23"
+
+tmp@^0.2.4:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -7699,6 +7827,11 @@ yaml@^1.10.0:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
+
+yaml@^2.2.2:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.4.tgz#4b5f411dd25f9544914d8673d4da7f29248e5e2e"
+  integrity sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==
 
 yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
This PR adds a shell script to generate security and CSP headers for the docker image's NGINX config.
It runs on container startup, and get's its values from the environment, same as the runtime config generation CLI.

**Note:** Testing this locally, there is currently an error with one of our dependencies that show up in the browser console:
```
Content-Security-Policy: The page’s settings blocked a JavaScript eval (script-src) from being executed because it violates the following directive: “script-src 'self'” (Missing 'unsafe-eval')
```
This comes from the `cbor-x` module.

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Related issues / tickets
<!-- Link issues with keywords to auto-close, e.g. "Fixes #123" -->
- Fixes #36

## How to test
<!-- Provide step-by-step instructions -->
1. Build docker image based on this PR.
2. Start it.
3. You should see the correct headers in the responses.

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

