### PR TITLE
feat(oid4vp): add W3C DC API response delivery via postMessage

### DIFF
--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -274,11 +274,78 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 						logger.debug("User selection:", selection);
 						const res = await sendAuthorizationResponse(selection, vcEntityList);
 
+						if (res && 'dcApiResponse' in res && res.dcApiResponse && window.opener) {
+							// DC API: deliver VP response via postMessage to opener (browser extension)
+							logger.debug("Delivering DC API response via postMessage");
+							window.opener.postMessage({
+								type: 'DC_WALLET_RESPONSE',
+								response: res.dcApiResponse,
+							}, '*');
+							window.close();
+							return;
+						}
+
 						if (res && 'url' in res && res.url) {
 							setRedirectUri(res.url);
 						}
 					} catch (err) {
 						logger.error("Failed to handle authorization request:", err);
+						window.history.replaceState({}, '', `${window.location.pathname}`);
+					}
+				})();
+				return;
+			}
+			else if (u.searchParams.get('client_id') && u.searchParams.get('response_type') === 'vp_token' && !u.searchParams.get('request_uri')) {
+				// Handle inline OID4VP authorization request (DC API / browser extension flow)
+				(async () => {
+					try {
+						const result = await handleAuthorizationRequest(u.toString(), vcEntityList);
+						logger.debug("DC API authorization request result:", result);
+
+						if ('error' in result) {
+							if (result.error === HandleAuthorizationRequestErrors.INSUFFICIENT_CREDENTIALS) {
+								displayError({
+									title: t('messagePopup.insufficientCredentials.title'),
+									description: t('messagePopup.insufficientCredentials.description')
+								});
+							} else if (result.error === HandleAuthorizationRequestErrors.NONTRUSTED_VERIFIER) {
+								displayError({
+									title: t('messagePopup.nonTrustedVerifier.title'),
+									description: t('messagePopup.nonTrustedVerifier.description')
+								});
+							}
+							return;
+						}
+
+						const { conformantCredentialsMap, verifierDomainName, verifierPurpose, parsedTransactionData } = result;
+						const jsonedMap = Object.fromEntries(conformantCredentialsMap);
+						logger.debug("Prompting for credential selection...");
+
+						const selection = await promptForCredentialSelection(jsonedMap, verifierDomainName, verifierPurpose, parsedTransactionData);
+
+						if (!(selection instanceof Map)) {
+							return;
+						}
+
+						logger.debug("User selection:", selection);
+						const res = await sendAuthorizationResponse(selection, vcEntityList);
+
+						if (res && 'dcApiResponse' in res && res.dcApiResponse && window.opener) {
+							// DC API: deliver VP response via postMessage to opener
+							logger.debug("Delivering DC API response via postMessage");
+							window.opener.postMessage({
+								type: 'DC_WALLET_RESPONSE',
+								response: res.dcApiResponse,
+							}, '*');
+							window.close();
+							return;
+						}
+
+						if (res && 'url' in res && res.url) {
+							setRedirectUri(res.url);
+						}
+					} catch (err) {
+						logger.error("Failed to handle DC API authorization request:", err);
 						window.history.replaceState({}, '', `${window.location.pathname}`);
 					}
 				})();

--- a/src/hooks/useOID4VPFlow.ts
+++ b/src/hooks/useOID4VPFlow.ts
@@ -250,6 +250,13 @@ export function useOID4VPFlow(options: UseOID4VPFlowOptions = {}): UseOID4VPFlow
 				);
 
 				// Check result type
+				if ('dcApiResponse' in result && result.dcApiResponse) {
+					return {
+						success: true,
+						responseData: result.dcApiResponse,
+					};
+				}
+
 				if ('url' in result && result.url) {
 					return {
 						success: true,

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -156,12 +156,13 @@ export function useOpenID4VP({
 		if (!response || !(response as any).formData) {
 			return {};
 		}
-		const { formData, generatedVPs, filteredVCEntities, response_uri, client_id } = response as {
+		const { formData, generatedVPs, filteredVCEntities, response_uri, client_id, response_mode } = response as {
 			formData: URLSearchParams;
 			generatedVPs: string[];
 			filteredVCEntities: ExtendedVcEntity[];
 			response_uri: string;
 			client_id: string;
+			response_mode: OpenID4VPResponseMode;
 		};
 
 		const transactionId = WalletStateUtils.getRandomUint32();
@@ -177,6 +178,15 @@ export function useOpenID4VP({
 		}));
 		await api.updatePrivateData(newPrivateData);
 		await keystoreCommit();
+
+		// DC API: return VP response data for postMessage delivery (no HTTP POST)
+		if (response_mode === OpenID4VPResponseMode.DC_API || response_mode === OpenID4VPResponseMode.DC_API_JWT) {
+			const vpResponseData: Record<string, string> = {};
+			for (const [key, value] of formData.entries()) {
+				vpResponseData[key] = value;
+			}
+			return { dcApiResponse: vpResponseData };
+		}
 
 		const bodyString = formData.toString();
 		logger.debug('bodyString: ', bodyString)

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -415,12 +415,14 @@ export class WebSocketTransport implements IFlowTransport {
 			result.transactionData = response.transactionData as OID4VPFlowResult['transactionData'];
 		}
 
-		// Submission result
-		if (response.redirectUri) {
-			result.redirectUri = response.redirectUri as string;
+		// Submission result (support both snake_case from backend and camelCase)
+		const redirectUri = (response.redirect_uri || response.redirectUri) as string | undefined;
+		if (redirectUri) {
+			result.redirectUri = redirectUri;
 		}
-		if (response.responseData) {
-			result.responseData = response.responseData;
+		const responseData = response.response_data || response.responseData;
+		if (responseData) {
+			result.responseData = responseData;
 		}
 
 		return result;

--- a/src/lib/transport/types/OID4VPTypes.ts
+++ b/src/lib/transport/types/OID4VPTypes.ts
@@ -115,4 +115,6 @@ export type OID4VPResponseMode =
 	| 'direct_post'
 	| 'direct_post.jwt'
 	| 'fragment'
-	| 'query';
+	| 'query'
+	| 'dc_api'
+	| 'dc_api.jwt';


### PR DESCRIPTION
Add dc_api response mode support for the W3C Digital Credentials API flow.

**Stacked on** feat/v2-openid-transports

When `response_mode=dc_api`, the VP response is delivered via `window.opener.postMessage()` to the browser extension (wallet-companion) instead of being POSTed to a verifier endpoint.

## Changes

### UriHandlerProvider.tsx
- Detect inline OID4VP authorization requests (`client_id` + `response_type=vp_token`, no `request_uri`) for DC API browser extension flow
- After VP generation with `dc_api` response_mode, deliver response via `window.opener.postMessage({type: "DC_WALLET_RESPONSE", response: vpData})` and close the tab

### OpenID4VP.ts (HTTP proxy transport)
- Check `response_mode` from `createAuthorizationResponse()` before POSTing to verifier
- For `dc_api`/`dc_api.jwt`, return `{dcApiResponse: formData}` instead of HTTP POST

### WebSocketTransport.ts
- Handle both snake_case (`response_data`, `redirect_uri`) and camelCase field names from backend

### OID4VPTypes.ts
- Add `dc_api` and `dc_api.jwt` to `OID4VPResponseMode` type

### useOID4VPFlow.ts
- Handle `dcApiResponse` result type from HTTP proxy transport

## Dependencies

- sirosfoundation/wallet-common#7 — response_mode parsing fix + exposure in createAuthorizationResponse
- sirosfoundation/go-wallet-backend#107 — backend dc_api response mode (for WebSocket transport path)

## Closes

- #76
- Ref: #77
