### PR TITLE
refactor: consolidate OID4VCI flow logic into useOID4VCIFlow hook

### DIFF
--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -143,6 +143,7 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 						window.location.href = result.authorizationUrl;
 					}
 					if (!result.success) {
+						logger.error('[Uri Handler]: credential offer processing failed', result.error ?? result);
 						window.history.replaceState({}, '', `${window.location.pathname}`);
 					}
 				})();
@@ -155,7 +156,10 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 				(async () => {
 					const result = await hookHandleAuthResponse(u.toString());
 					if (!result.success) {
-						logger.error("Error during the handling of authorization response");
+						logger.error("Error during the handling of authorization response", {
+							code: result.error?.code,
+							message: result.error?.message,
+						});
 						window.history.replaceState({}, '', `${window.location.pathname}`);
 					}
 				})();

--- a/src/hocs/UriHandlerProvider.tsx
+++ b/src/hocs/UriHandlerProvider.tsx
@@ -5,8 +5,6 @@ import { logger } from "@/logger";
 import SessionContext from "../context/SessionContext";
 import { useTranslation } from "react-i18next";
 import { HandleAuthorizationRequestErrors } from "wallet-common";
-import OpenID4VCIContext from "../context/OpenID4VCIContext";
-import { InvalidTxCodeError, RawTxCodeSpec } from "@/lib/services/OpenID4VCI/OpenID4VCI";
 import OpenID4VPContext from "../context/OpenID4VPContext";
 import CredentialsContext from "@/context/CredentialsContext";
 import { CachedUser } from "@/services/LocalStorageKeystore";
@@ -15,6 +13,7 @@ import { useSessionStorage } from "@/hooks/useStorage";
 import { useTxCodeInput } from "@/context/TxCodeInputContext";
 import TxCodeInputPopup from "@/components/Popups/TxCodeInputPopup";
 import useErrorDialog from "@/hooks/useErrorDialog";
+import { useOID4VCIFlow } from "@/hooks/useOID4VCIFlow";
 
 const PinInputPopup = React.lazy(() => import('../components/Popups/PinInput'));
 
@@ -22,10 +21,10 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 	const { isOnline } = useContext(StatusContext);
 	const { requestTxCode, state: txCodeState, handleSubmit: handleTxCodeSubmit, handleCancel: handleTxCodeCancel } = useTxCodeInput();
 	const { displayError } = useErrorDialog();
+	const { processCredentialOffer, handleAuthorizationResponse: hookHandleAuthResponse } = useOID4VCIFlow();
 
 	const [usedAuthorizationCodes, setUsedAuthorizationCodes] = useState<string[]>([]);
 	const [usedRequestUris, setUsedRequestUris] = useState<string[]>([]);
-	const [usedPreAuthorizedCodes, setUsedPreAuthorizedCodes] = useState<string[]>([]);
 
 	const { isLoggedIn, api, keystore, logout } = useContext(SessionContext);
 	const { syncPrivateData } = api;
@@ -34,10 +33,8 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 	const location = useLocation();
 	const [url, setUrl] = useState(window.location.href);
 
-	const { openID4VCI } = useContext(OpenID4VCIContext);
 	const { openID4VP } = useContext(OpenID4VPContext);
 
-	const { handleCredentialOffer, generateAuthorizationRequest, handleAuthorizationResponse, requestCredentialsWithPreAuthorization } = openID4VCI;
 	const { handleAuthorizationRequest, promptForCredentialSelection, sendAuthorizationResponse } = openID4VP;
 
 	const [showPinInputPopup, setShowPinInputPopup] = useState<boolean>(false);
@@ -127,7 +124,6 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 	useEffect(() => {
 		if (
 			!isLoggedIn || !url || !t || !vcEntityList || !synced ||
-			!handleCredentialOffer || !generateAuthorizationRequest || !handleAuthorizationResponse ||
 			!handleAuthorizationRequest || !promptForCredentialSelection || !sendAuthorizationResponse
 		) return;
 
@@ -138,88 +134,16 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 			logger.debug('[Uri Handler]: check', u.toString());
 
 			if (u.protocol === 'openid-credential-offer' || u.searchParams.get('credential_offer') || u.searchParams.get('credential_offer_uri')) {
-				// Handle credential offer with async/await for proper React state updates
 				(async () => {
-					try {
-						const offer = await handleCredentialOffer(u.toString());
-						const { credentialIssuer, selectedCredentialConfigurationId, issuer_state, preAuthorizedCode, txCode } = offer;
-
-						logger.debug("Handling credential offer...", { credentialIssuer, preAuthorizedCode: !!preAuthorizedCode });
-
-						if (!preAuthorizedCode) {
-							// Authorization code flow - redirect to authorization
-							logger.debug("Generating authorization request...");
-							const authResult = await generateAuthorizationRequest(credentialIssuer, selectedCredentialConfigurationId, issuer_state);
-							if ('url' in authResult && typeof authResult.url === 'string' && authResult.url) {
-								window.location.href = authResult.url;
-							}
-							return;
-						}
-
-						// Check for pre-authorized code replay
-						if (usedPreAuthorizedCodes.includes(preAuthorizedCode)) {
-							logger.debug("Already used pre-authorized code, ignoring");
-							return;
-						}
-						setUsedPreAuthorizedCodes((codes) => [...codes, preAuthorizedCode]);
-
-						// Pre-authorized code flow
-						let userInput: string | undefined = undefined;
-						if (txCode) {
-							try {
-								// Use React popup instead of blocking prompt()
-							const rawTxCode = txCode as RawTxCodeSpec;
-								userInput = await requestTxCode({
-									description: rawTxCode.description ?? undefined,
-									length: rawTxCode.length ?? undefined,
-									inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
-								});
-							} catch (err) {
-								// User cancelled tx code input
-								logger.info("User cancelled transaction code input");
-								window.history.replaceState({}, '', `${window.location.pathname}`);
-								return;
-							}
-						}
-
-						logger.debug("Requesting credential with pre-authorization...");
-						const maxTxCodeRetries = 3;
-						for (let attempt = 0; attempt <= maxTxCodeRetries; attempt++) {
-							try {
-								const result = await requestCredentialsWithPreAuthorization(
-									credentialIssuer,
-									selectedCredentialConfigurationId,
-									preAuthorizedCode,
-									userInput
-								);
-
-								if ('url' in result && typeof result.url === 'string' && result.url) {
-									window.location.href = result.url;
-								}
-								break;
-							} catch (retryErr) {
-								if (retryErr instanceof InvalidTxCodeError && txCode && attempt < maxTxCodeRetries) {
-									logger.info("Invalid transaction code, prompting for retry");
-									try {
-										const rawTxCode = txCode as RawTxCodeSpec;
-										userInput = await requestTxCode({
-											description: t('txCodeInput.errorInvalid'),
-											length: rawTxCode.length ?? undefined,
-											inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
-										});
-									} catch (_cancelErr) {
-										logger.info("User cancelled transaction code retry");
-										window.history.replaceState({}, '', `${window.location.pathname}`);
-										return;
-									}
-									continue;
-								}
-								throw retryErr;
-							}
-						}
-					} catch (err) {
+					const result = await processCredentialOffer(u.toString(), {
+						requestTxCode,
+						txCodeRetryDescription: t('txCodeInput.errorInvalid'),
+					});
+					if (result.authorizationUrl) {
+						window.location.href = result.authorizationUrl;
+					}
+					if (!result.success) {
 						window.history.replaceState({}, '', `${window.location.pathname}`);
-						logger.error("Error handling credential offer:", err);
 					}
 				})();
 				return;
@@ -229,10 +153,9 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 
 				logger.debug("Handling authorization response...");
 				(async () => {
-					try {
-						await handleAuthorizationResponse(u.toString());
-					} catch (err) {
-						logger.error("Error during the handling of authorization response:", err);
+					const result = await hookHandleAuthResponse(u.toString());
+					if (!result.success) {
+						logger.error("Error during the handling of authorization response");
 						window.history.replaceState({}, '', `${window.location.pathname}`);
 					}
 				})();
@@ -307,15 +230,14 @@ export const UriHandlerProvider = ({ children }: React.PropsWithChildren) => {
 		getCalculatedWalletState,
 		usedAuthorizationCodes,
 		usedRequestUris,
-		// depend on methods, not whole context objects
-		handleCredentialOffer,
-		generateAuthorizationRequest,
-		handleAuthorizationResponse,
+		// OID4VCI: hook-based
+		processCredentialOffer,
+		hookHandleAuthResponse,
+		requestTxCode,
+		// OID4VP: context-based
 		handleAuthorizationRequest,
 		promptForCredentialSelection,
 		sendAuthorizationResponse,
-		requestCredentialsWithPreAuthorization,
-		requestTxCode,
 		displayError,
 	]);
 

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -33,7 +33,7 @@ export type TxCodeRequestFn = (config: {
 export interface ProcessCredentialOfferOptions {
 	/** Callback to prompt user for transaction code. Required for pre-auth offers with tx_code. */
 	requestTxCode?: TxCodeRequestFn;
-	/** Maximum TX code retry attempts on InvalidTxCodeError (default: 3) */
+	/** Maximum number of TX code retries after the initial attempt (default: 2, so 3 total attempts) */
 	maxTxCodeRetries?: number;
 	/** Description shown when re-prompting after invalid TX code */
 	txCodeRetryDescription?: string;
@@ -349,7 +349,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		credentialOfferUri: string,
 		options: ProcessCredentialOfferOptions = {},
 	): Promise<OID4VCIFlowResult> => {
-		const { requestTxCode, maxTxCodeRetries = 3, txCodeRetryDescription } = options;
+		const { requestTxCode, maxTxCodeRetries = 2, txCodeRetryDescription } = options;
 
 		setIsLoading(true);
 		setError(null);
@@ -386,6 +386,12 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 						offer.selectedCredentialConfigurationId,
 						offer.issuer_state,
 					);
+					if (!authResult?.url) {
+						return {
+							success: false,
+							error: { code: 'AUTH_REQUEST_ERROR', message: 'Failed to generate authorization request URL' },
+						};
+					}
 					return {
 						success: true,
 						authorizationUrl: authResult.url,
@@ -399,49 +405,63 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 				}
 				usedPreAuthCodesRef.current.add(offer.preAuthorizedCode);
 
-				// Prompt for TX code if required
-				let txCodeInput: string | undefined;
-				if (offer.txCode && requestTxCode) {
-					const rawTxCode = offer.txCode as RawTxCodeSpec;
-					txCodeInput = await requestTxCode({
-						description: rawTxCode.description ?? undefined,
-						length: rawTxCode.length ?? undefined,
-						inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
-					});
+				// TX code is required but no callback to prompt user
+				if (offer.txCode && !requestTxCode) {
+					usedPreAuthCodesRef.current.delete(offer.preAuthorizedCode);
+					return {
+						success: false,
+						error: { code: 'TX_CODE_REQUIRED', message: 'Transaction code required but no requestTxCode callback provided' },
+					};
 				}
 
-				// Request credential with pre-authorization, retrying on invalid TX code
-				logger.debug("Requesting credential with pre-authorization...");
-				for (let attempt = 0; attempt <= maxTxCodeRetries; attempt++) {
-					try {
-						await openID4VCI.requestCredentialsWithPreAuthorization(
-							offer.credentialIssuer,
-							offer.selectedCredentialConfigurationId,
-							offer.preAuthorizedCode,
-							txCodeInput,
-						);
-						return { success: true };
-					} catch (retryErr) {
-						if (
-							retryErr instanceof InvalidTxCodeError &&
-							offer.txCode &&
-							requestTxCode &&
-							attempt < maxTxCodeRetries
-						) {
-							logger.info("Invalid transaction code, prompting for retry");
-							const rawTxCode = offer.txCode as RawTxCodeSpec;
-							txCodeInput = await requestTxCode({
-								description: txCodeRetryDescription ?? rawTxCode.description ?? undefined,
-								length: rawTxCode.length ?? undefined,
-								inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
-							});
-							continue;
-						}
-						throw retryErr;
+				try {
+					// Prompt for TX code if required
+					let txCodeInput: string | undefined;
+					if (offer.txCode && requestTxCode) {
+						const rawTxCode = offer.txCode as RawTxCodeSpec;
+						txCodeInput = await requestTxCode({
+							description: rawTxCode.description ?? undefined,
+							length: rawTxCode.length ?? undefined,
+							inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
+						});
 					}
-				}
 
-				return { success: true };
+					// Request credential with pre-authorization, retrying on invalid TX code
+					logger.debug("Requesting credential with pre-authorization...");
+					for (let attempt = 0; attempt <= maxTxCodeRetries; attempt++) {
+						try {
+							await openID4VCI.requestCredentialsWithPreAuthorization(
+								offer.credentialIssuer,
+								offer.selectedCredentialConfigurationId,
+								offer.preAuthorizedCode,
+								txCodeInput,
+							);
+							return { success: true };
+						} catch (retryErr) {
+							if (
+								retryErr instanceof InvalidTxCodeError &&
+								offer.txCode &&
+								requestTxCode &&
+								attempt < maxTxCodeRetries
+							) {
+								logger.info("Invalid transaction code, prompting for retry");
+								const rawTxCode = offer.txCode as RawTxCodeSpec;
+								txCodeInput = await requestTxCode({
+									description: txCodeRetryDescription ?? rawTxCode.description ?? undefined,
+									length: rawTxCode.length ?? undefined,
+									inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
+								});
+								continue;
+							}
+							throw retryErr;
+						}
+					}
+
+					return { success: true };
+				} catch (preAuthErr) {
+					usedPreAuthCodesRef.current.delete(offer.preAuthorizedCode);
+					throw preAuthErr;
+				}
 			}
 
 			throw new Error('No transport available for credential issuance');

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -13,6 +13,8 @@ import OpenID4VCIContext from '@/context/OpenID4VCIContext';
 import { CredentialOfferSchema } from 'wallet-common';
 import type { OID4VCIFlowResult } from '@/lib/transport/types/OID4VCITypes';
 import type { FlowProgressEvent, TransportType } from '@/lib/transport/types/FlowTypes';
+import { InvalidTxCodeError, RawTxCodeSpec } from '@/lib/services/OpenID4VCI/OpenID4VCI';
+import { logger } from '@/logger';
 
 export interface UseOID4VCIFlowOptions {
 	/** Called when flow progress updates */
@@ -21,7 +23,35 @@ export interface UseOID4VCIFlowOptions {
 	onError?: (error: Error) => void;
 }
 
+/** Callback for requesting TX code input from user */
+export type TxCodeRequestFn = (config: {
+	description?: string;
+	length?: number;
+	inputMode?: 'numeric' | 'text';
+}) => Promise<string>;
+
+export interface ProcessCredentialOfferOptions {
+	/** Callback to prompt user for transaction code. Required for pre-auth offers with tx_code. */
+	requestTxCode?: TxCodeRequestFn;
+	/** Maximum TX code retry attempts on InvalidTxCodeError (default: 3) */
+	maxTxCodeRetries?: number;
+	/** Description shown when re-prompting after invalid TX code */
+	txCodeRetryDescription?: string;
+}
+
 export interface UseOID4VCIFlowReturn {
+	/**
+	 * Process a credential offer end-to-end:
+	 * - Parses the offer and determines flow type (auth-code vs pre-auth)
+	 * - Auth-code flow: generates authorization request, returns authorizationUrl
+	 * - Pre-auth flow: prompts for TX code if needed, handles retries, issues credential
+	 * - Includes pre-authorized code replay protection
+	 */
+	processCredentialOffer: (
+		credentialOfferUri: string,
+		options?: ProcessCredentialOfferOptions,
+	) => Promise<OID4VCIFlowResult>;
+
 	/** Start an OID4VCI flow with a credential offer URI */
 	handleCredentialOffer: (credentialOfferUri: string) => Promise<OID4VCIFlowResult>;
 
@@ -71,6 +101,9 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		credentialIssuer: string;
 		selectedCredentialConfigurationId: string;
 	} | null>(null);
+
+	// Track used pre-authorized codes to prevent replay within this session
+	const usedPreAuthCodesRef = useRef<Set<string>>(new Set());
 
 	const transportType = transportContext?.transportType ?? 'none';
 	const transport = transportContext?.transport;
@@ -306,7 +339,131 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		}
 	}, [transportType, transport, openID4VCI, onProgress, onError]);
 
+	/**
+	 * Process a credential offer end-to-end.
+	 * For WebSocket transport, delegates the entire flow to the backend.
+	 * For HTTP proxy, orchestrates offer parsing, flow routing, TX code prompting,
+	 * and credential request with retry logic.
+	 */
+	const processCredentialOffer = useCallback(async (
+		credentialOfferUri: string,
+		options: ProcessCredentialOfferOptions = {},
+	): Promise<OID4VCIFlowResult> => {
+		const { requestTxCode, maxTxCodeRetries = 3, txCodeRetryDescription } = options;
+
+		setIsLoading(true);
+		setError(null);
+
+		try {
+			validateCredentialOffer(credentialOfferUri);
+
+			// WebSocket transport: delegate entire flow to backend
+			if (transportType === 'websocket' && transport) {
+				const unsubscribeProgress = onProgress
+					? transport.onProgress(onProgress)
+					: () => {};
+				const unsubscribeError = onError
+					? transport.onError(onError)
+					: () => {};
+
+				try {
+					return await transport.startOID4VCIFlow({ credentialOfferUri });
+				} finally {
+					unsubscribeProgress();
+					unsubscribeError();
+				}
+			}
+
+			// HTTP proxy transport: orchestrate the full flow
+			if (transportType === 'http_proxy' && openID4VCI) {
+				const offer = await openID4VCI.handleCredentialOffer(credentialOfferUri);
+
+				// Auth-code flow: generate authorization request and return URL
+				if (!offer.preAuthorizedCode) {
+					logger.debug("Generating authorization request...");
+					const authResult = await openID4VCI.generateAuthorizationRequest(
+						offer.credentialIssuer,
+						offer.selectedCredentialConfigurationId,
+						offer.issuer_state,
+					);
+					return {
+						success: true,
+						authorizationUrl: authResult.url,
+					};
+				}
+
+				// Pre-auth replay protection
+				if (usedPreAuthCodesRef.current.has(offer.preAuthorizedCode)) {
+					logger.debug("Already used pre-authorized code, ignoring");
+					return { success: true };
+				}
+				usedPreAuthCodesRef.current.add(offer.preAuthorizedCode);
+
+				// Prompt for TX code if required
+				let txCodeInput: string | undefined;
+				if (offer.txCode && requestTxCode) {
+					const rawTxCode = offer.txCode as RawTxCodeSpec;
+					txCodeInput = await requestTxCode({
+						description: rawTxCode.description ?? undefined,
+						length: rawTxCode.length ?? undefined,
+						inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
+					});
+				}
+
+				// Request credential with pre-authorization, retrying on invalid TX code
+				logger.debug("Requesting credential with pre-authorization...");
+				for (let attempt = 0; attempt <= maxTxCodeRetries; attempt++) {
+					try {
+						await openID4VCI.requestCredentialsWithPreAuthorization(
+							offer.credentialIssuer,
+							offer.selectedCredentialConfigurationId,
+							offer.preAuthorizedCode,
+							txCodeInput,
+						);
+						return { success: true };
+					} catch (retryErr) {
+						if (
+							retryErr instanceof InvalidTxCodeError &&
+							offer.txCode &&
+							requestTxCode &&
+							attempt < maxTxCodeRetries
+						) {
+							logger.info("Invalid transaction code, prompting for retry");
+							const rawTxCode = offer.txCode as RawTxCodeSpec;
+							txCodeInput = await requestTxCode({
+								description: txCodeRetryDescription ?? rawTxCode.description ?? undefined,
+								length: rawTxCode.length ?? undefined,
+								inputMode: rawTxCode.input_mode === 'numeric' ? 'numeric' : 'text',
+							});
+							continue;
+						}
+						throw retryErr;
+					}
+				}
+
+				return { success: true };
+			}
+
+			throw new Error('No transport available for credential issuance');
+
+		} catch (err) {
+			const error = err instanceof Error ? err : new Error(String(err));
+			setError(error);
+			onError?.(error);
+			return {
+				success: false,
+				error: {
+					code: 'FLOW_ERROR',
+					message: error.message,
+				},
+			};
+		} finally {
+			setIsLoading(false);
+		}
+	}, [transportType, transport, openID4VCI, onProgress, onError, validateCredentialOffer]);
+
 	return {
+		processCredentialOffer,
 		handleCredentialOffer,
 		handleAuthorizationResponse,
 		requestWithPreAuthorization,


### PR DESCRIPTION
## Summary

Moves credential offer orchestration logic from `UriHandlerProvider` into the `useOID4VCIFlow` hook, making it the single entry point for OID4VCI flows.

Addresses feedback that too much OID4VCI protocol logic lives outside the hook, making it harder for consumers to use.

## Changes

### `useOID4VCIFlow.ts` (+157 lines)
- **New `processCredentialOffer()` method** — handles the full credential offer lifecycle:
  - Parses the offer and determines flow type (auth-code vs pre-auth)
  - Auth-code flow: generates authorization request, returns `authorizationUrl`
  - Pre-auth flow: prompts for TX code via callback, retries on `InvalidTxCodeError` (up to 3 attempts)
  - Includes pre-authorized code replay protection (ref-based `Set`)
  - WebSocket transport: delegates entire flow to backend
- **New `TxCodeRequestFn` type** — UI-agnostic callback for TX code prompting
- **New `ProcessCredentialOfferOptions` interface** — configurable retry count and retry description
- Existing lower-level methods (`handleCredentialOffer`, `requestWithPreAuthorization`, `handleAuthorizationResponse`) retained for advanced consumers

### `UriHandlerProvider.tsx` (−96 lines)
- Credential offer handling block: **~80 lines → ~14 lines** (single `processCredentialOffer()` call)
- Authorization response handling: uses hook `handleAuthorizationResponse` (result-based instead of try/catch)
- Removed: `OpenID4VCIContext` import, `InvalidTxCodeError`/`RawTxCodeSpec` imports, `usedPreAuthorizedCodes` state, TX code retry loop, flow routing logic
- Retained: `useTxCodeInput()` for popup rendering + passing `requestTxCode` callback to hook

## Consumer usage

```tsx
const { processCredentialOffer } = useOID4VCIFlow();
const { requestTxCode } = useTxCodeInput();

const result = await processCredentialOffer(offerUri, {
  requestTxCode,
  txCodeRetryDescription: t('txCodeInput.errorInvalid'),
});

if (result.authorizationUrl) {
  window.location.href = result.authorizationUrl;
}
```

## Verification

- TypeScript compiles cleanly (no new errors)
- All pre-existing errors unchanged (OIDCGateUI, mdocProtocol, worker — unrelated)