### PR TITLE
feat: WebSocket trust handler for client-side trust evaluation

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -15,6 +15,7 @@ import { AppSettingsProvider } from './context/AppSettingsProvider';
 import { NotificationProvider } from './context/NotificationProvider';
 import { FlowTransportProviderWrapper } from './context/FlowTransportProviderWrapper';
 import { WebSocketSignHandlerProvider } from './context/WebSocketSignHandlerProvider';
+import { WebSocketTrustHandlerProvider } from './context/WebSocketTrustHandlerProvider';
 import { ErrorDialogContextProvider } from './context/ErrorDialogContextProvider';
 import { TxCodeInputProvider } from './context/TxCodeInputContext';
 
@@ -33,6 +34,7 @@ const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 				<CredentialsContextProvider>
 					<FlowTransportProviderWrapper>
 						<WebSocketSignHandlerProvider>
+						<WebSocketTrustHandlerProvider>
 							<I18nextProvider i18n={i18n}>
 										<ErrorDialogContextProvider>
 											<OpenID4VPContextProvider>
@@ -52,6 +54,7 @@ const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 											</OpenID4VPContextProvider>
 										</ErrorDialogContextProvider>
 									</I18nextProvider>
+						</WebSocketTrustHandlerProvider>
 						</WebSocketSignHandlerProvider>
 					</FlowTransportProviderWrapper>
 				</CredentialsContextProvider>

--- a/src/context/FlowTransportContext.tsx
+++ b/src/context/FlowTransportContext.tsx
@@ -38,6 +38,9 @@ export type {
 	MatchRequest as WSMatchRequest,
 	MatchResponse as WSMatchResponse,
 	MatchRequestHandler as WSMatchRequestHandler,
+	TrustEvaluationRequest as WSTrustEvaluationRequest,
+	TrustEvaluationResponse as WSTrustEvaluationResponse,
+	TrustEvaluationHandler as WSTrustEvaluationHandler,
 } from '@/lib/transport/WebSocketTransport';
 
 /**
@@ -66,6 +69,8 @@ interface FlowTransportContextValue {
 	registerSignHandler: (handler: SignRequestHandler) => () => void;
 	/** Register a match request handler for client-side credential matching (for WebSocket) */
 	registerMatchHandler: (handler: MatchRequestHandler) => () => void;
+	/** Register a trust evaluation handler for client-side trust evaluation (for WebSocket) */
+	registerTrustHandler: (handler: import('@/lib/transport/WebSocketTransport').TrustEvaluationHandler) => () => void;
 }
 
 const FlowTransportContext = createContext<FlowTransportContextValue | null>(null);
@@ -256,6 +261,14 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 		return () => {};
 	}, [wsTransport]);
 
+	// Register trust handler on WebSocket transport for client-side trust evaluation
+	const registerTrustHandler = useCallback((handler: import('@/lib/transport/WebSocketTransport').TrustEvaluationHandler): (() => void) => {
+		if (wsTransport) {
+			return wsTransport.onTrustEvaluation(handler);
+		}
+		return () => {};
+	}, [wsTransport]);
+
 	const value = useMemo(() => ({
 		transport,
 		transportType,
@@ -268,7 +281,8 @@ export const FlowTransportProvider: React.FC<FlowTransportProviderProps> = ({
 		engineCapabilities,
 		registerSignHandler,
 		registerMatchHandler,
-	}), [transport, transportType, isConnected, reconnect, availableTransports, lastError, clearError, capabilitiesLoaded, engineCapabilities, registerSignHandler, registerMatchHandler]);
+		registerTrustHandler,
+	}), [transport, transportType, isConnected, reconnect, availableTransports, lastError, clearError, capabilitiesLoaded, engineCapabilities, registerSignHandler, registerMatchHandler, registerTrustHandler]);
 
 	return (
 		<FlowTransportContext.Provider value={value}>

--- a/src/context/WebSocketTrustHandlerProvider.tsx
+++ b/src/context/WebSocketTrustHandlerProvider.tsx
@@ -1,0 +1,29 @@
+/**
+ * WebSocket Trust Handler Provider
+ *
+ * This component sets up the trust evaluation handler for WebSocket transport.
+ * It should be placed inside SessionContext, FlowTransportContext, and where
+ * useHttpProxy is available.
+ */
+
+import React from 'react';
+import { useWebSocketTrustHandler } from '@/hooks/useWebSocketTrustHandler';
+
+interface WebSocketTrustHandlerProviderProps {
+	children: React.ReactNode;
+}
+
+/**
+ * Provider component that activates the WebSocket trust handler.
+ * Renders children unchanged - only side effect is registering the handler.
+ */
+export const WebSocketTrustHandlerProvider: React.FC<WebSocketTrustHandlerProviderProps> = ({
+	children,
+}) => {
+	// Register the trust handler
+	useWebSocketTrustHandler();
+
+	return <>{children}</>;
+};
+
+export default WebSocketTrustHandlerProvider;

--- a/src/hooks/useWebSocketTrustHandler.ts
+++ b/src/hooks/useWebSocketTrustHandler.ts
@@ -73,9 +73,22 @@ export function useWebSocketTrustHandler(): void {
 		};
 
 		// Map key material from backend format to TrustEvaluator format
-		const keyMaterial = request.keyMaterial
-			? { type: request.keyMaterial.type, key: request.keyMaterial.x5c ?? request.keyMaterial.jwk }
-			: undefined;
+		let keyMaterial: { type: string; key: unknown } | undefined;
+		if (request.keyMaterial) {
+			if (request.keyMaterial.type === 'x5c') {
+				if (request.keyMaterial.x5c === undefined) {
+					logger.warn('[WS Trust Handler] Invalid key material: missing x5c for type x5c');
+					return { trusted: false, reason: 'Invalid key material: missing x5c for type x5c' };
+				}
+				keyMaterial = { type: request.keyMaterial.type, key: request.keyMaterial.x5c };
+			} else if (request.keyMaterial.type === 'jwk') {
+				if (request.keyMaterial.jwk === undefined) {
+					logger.warn('[WS Trust Handler] Invalid key material: missing jwk for type jwk');
+					return { trusted: false, reason: 'Invalid key material: missing jwk for type jwk' };
+				}
+				keyMaterial = { type: request.keyMaterial.type, key: request.keyMaterial.jwk };
+			}
+		}
 
 		if (request.subjectType === 'credential_issuer') {
 			const evaluateIssuer = createIssuerTrustEvaluator(config);

--- a/src/hooks/useWebSocketTrustHandler.ts
+++ b/src/hooks/useWebSocketTrustHandler.ts
@@ -1,0 +1,143 @@
+/**
+ * WebSocket Trust Handler Hook
+ *
+ * This hook registers a trust evaluation handler with the WebSocket transport
+ * so that both HTTP proxy and WebSocket paths use the same TrustEvaluator
+ * interface for verifier and issuer trust evaluation.
+ *
+ * When the backend sends a flow_progress with trust_evaluation_required,
+ * this handler:
+ * - For 'credential_verifier': Calls createTrustEvaluator → AuthZEN /v1/evaluate
+ * - For 'credential_issuer': Calls createIssuerTrustEvaluator → AuthZEN /v1/evaluate
+ */
+
+import { useEffect, useContext, useCallback } from 'react';
+import { useFlowTransportSafe } from '@/context/FlowTransportContext';
+import type { WSTrustEvaluationRequest, WSTrustEvaluationResponse } from '@/context/FlowTransportContext';
+import StatusContext from '@/context/StatusContext';
+import { useApi } from '@/api';
+import { useHttpProxy } from '@/lib/services/HttpProxy/HttpProxy';
+import {
+	createTrustEvaluator,
+	createIssuerTrustEvaluator,
+	createDIDResolver,
+} from '@/lib/services/TrustEvaluator';
+import type { ClientIdScheme } from '@/lib/services/TrustEvaluator';
+import { BACKEND_URL } from '@/config';
+import { getTenantFromUrlPath } from '@/lib/tenant';
+import { logger } from '@/logger';
+
+/**
+ * Parse a subject ID into a ClientIdScheme based on context from the backend.
+ * The backend sends client_id_scheme in the context field.
+ */
+function parseClientIdScheme(subjectId: string, context?: Record<string, unknown>): ClientIdScheme {
+	const scheme = context?.client_id_scheme as string | undefined;
+
+	if (scheme === 'did' || subjectId.startsWith('did:')) {
+		return { scheme: 'did', clientId: subjectId, identifier: subjectId };
+	}
+	if (scheme === 'x509_san_dns') {
+		return { scheme: 'x509_san_dns', clientId: subjectId, identifier: subjectId };
+	}
+	if (scheme === 'pre-registered') {
+		return { scheme: 'pre-registered', clientId: subjectId, identifier: subjectId };
+	}
+	// Default: https
+	return { scheme: 'https', clientId: subjectId, identifier: subjectId };
+}
+
+/**
+ * Hook that registers a trust evaluation handler with the WebSocket transport.
+ * Should be used within SessionContext, FlowTransportContext, and where
+ * useHttpProxy is available.
+ */
+export function useWebSocketTrustHandler(): void {
+	const transportContext = useFlowTransportSafe();
+	const { isOnline } = useContext(StatusContext);
+	const api = useApi(isOnline);
+	const httpProxy = useHttpProxy();
+
+	const registerTrustHandler = transportContext?.registerTrustHandler;
+	const transportType = transportContext?.transportType;
+
+	// Trust handler callback
+	const handleTrustRequest = useCallback(async (request: WSTrustEvaluationRequest): Promise<WSTrustEvaluationResponse> => {
+		logger.debug('[WS Trust Handler] Received trust request:', request.subjectType, request.subjectId);
+
+		const config = {
+			httpClient: httpProxy,
+			backendUrl: BACKEND_URL,
+			getAuthToken: () => api.getAppToken() ?? '',
+			tenantId: getTenantFromUrlPath() ?? 'default',
+		};
+
+		// Map key material from backend format to TrustEvaluator format
+		const keyMaterial = request.keyMaterial
+			? { type: request.keyMaterial.type, key: request.keyMaterial.x5c ?? request.keyMaterial.jwk }
+			: undefined;
+
+		if (request.subjectType === 'credential_issuer') {
+			const evaluateIssuer = createIssuerTrustEvaluator(config);
+			const result = await evaluateIssuer({
+				issuerId: request.subjectId,
+				keyMaterial,
+				context: request.context,
+			});
+
+			logger.debug('[WS Trust Handler] Issuer trust result:', result.trusted);
+			return {
+				trusted: result.trusted,
+				name: result.name,
+				logo: result.logo,
+				metadata: result.metadata,
+			};
+		}
+
+		// credential_verifier: parse client_id_scheme and call verifier trust evaluator
+		const clientIdScheme = parseClientIdScheme(request.subjectId, request.context);
+
+		// For DID schemes with requires_resolution, resolve DID document first
+		if (request.requiresResolution && clientIdScheme.scheme === 'did') {
+			const resolveDid = createDIDResolver(config);
+			const resolution = await resolveDid(request.subjectId);
+			if (!resolution.resolved) {
+				logger.warn('[WS Trust Handler] DID resolution failed:', resolution.error);
+				return { trusted: false, reason: `DID resolution failed: ${resolution.error}` };
+			}
+		}
+
+		const evaluateTrust = createTrustEvaluator(config);
+		const result = await evaluateTrust({
+			clientIdScheme,
+			keyMaterial: keyMaterial ?? { type: 'jwk', key: {} },
+			requestUri: request.context?.request_uri as string | undefined,
+			responseUri: request.context?.response_uri as string | undefined,
+		});
+
+		logger.debug('[WS Trust Handler] Verifier trust result:', result.trusted);
+		return {
+			trusted: result.trusted,
+			name: result.name,
+			logo: result.logo,
+			metadata: result.metadata,
+		};
+	}, [httpProxy, api]);
+
+	// Register the trust handler when transport is websocket
+	useEffect(() => {
+		if (transportType !== 'websocket' || !registerTrustHandler) {
+			return;
+		}
+
+		logger.debug('[WS Trust Handler] Registering trust handler');
+		const unsubscribe = registerTrustHandler(handleTrustRequest);
+
+		return () => {
+			logger.debug('[WS Trust Handler] Unregistering trust handler');
+			unsubscribe();
+		};
+	}, [transportType, registerTrustHandler, handleTrustRequest]);
+}
+
+export default useWebSocketTrustHandler;

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -777,7 +777,24 @@ export class WebSocketTransport implements IFlowTransport {
 		const rawRequest = payload.request as Record<string, unknown> | undefined;
 		if (!rawRequest?.subject_id) {
 			logger.error('Malformed trust evaluation request: missing subject_id');
-			this.sendTrustResult(flowId, { trusted: false, reason: 'Malformed request' });
+			this.sendTrustResult(flowId, { trusted: false, reason: 'Malformed request: missing subject_id' });
+			return;
+		}
+
+		const SUPPORTED_SUBJECT_TYPES = ['credential_verifier', 'credential_issuer'] as const;
+		type SupportedSubjectType = (typeof SUPPORTED_SUBJECT_TYPES)[number];
+		const rawSubjectType = rawRequest.subject_type;
+		if (
+			!rawSubjectType ||
+			!SUPPORTED_SUBJECT_TYPES.includes(rawSubjectType as SupportedSubjectType)
+		) {
+			logger.error('Malformed trust evaluation request: missing or unknown subject_type', {
+				subject_type: rawSubjectType,
+			});
+			this.sendTrustResult(flowId, {
+				trusted: false,
+				reason: `Malformed request: unknown subject_type '${String(rawSubjectType)}'`,
+			});
 			return;
 		}
 

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -823,18 +823,38 @@ export class WebSocketTransport implements IFlowTransport {
 			return;
 		}
 
+		const payload: {
+			trusted: TrustEvaluationResponse['trusted'];
+			name?: TrustEvaluationResponse['name'];
+			logo?: TrustEvaluationResponse['logo'];
+			framework?: TrustEvaluationResponse['framework'];
+			reason?: TrustEvaluationResponse['reason'];
+			metadata?: TrustEvaluationResponse['metadata'];
+		} = {
+			trusted: response.trusted,
+		};
+
+		if (response.name !== undefined) {
+			payload.name = response.name;
+		}
+		if (response.logo !== undefined) {
+			payload.logo = response.logo;
+		}
+		if (response.framework !== undefined) {
+			payload.framework = response.framework;
+		}
+		if (response.reason !== undefined) {
+			payload.reason = response.reason;
+		}
+		if (response.metadata !== undefined) {
+			payload.metadata = response.metadata;
+		}
+
 		const msg = {
 			type: 'flow_action',
 			flow_id: flowId,
 			action: 'trust_result',
-			payload: {
-				trusted: response.trusted,
-				name: response.name ?? '',
-				logo: response.logo ?? '',
-				framework: response.framework ?? '',
-				reason: response.reason ?? '',
-				metadata: response.metadata ?? {},
-			},
+			payload,
 			timestamp: new Date().toISOString(),
 		};
 

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -559,7 +559,9 @@ export class WebSocketTransport implements IFlowTransport {
 		if (type === 'progress' || type === 'flow_progress') {
 			const payload = message.payload as Record<string, unknown> | undefined;
 			if (payload?.trust_evaluation_required) {
-				this.handleTrustEvaluationRequest(flowId, payload);
+				void this.handleTrustEvaluationRequest(flowId, payload).catch((error: unknown) => {
+					logger.error('Failed to handle trust evaluation request', { flowId, error });
+				});
 				return;
 			}
 			this.emitProgress({

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -101,6 +101,48 @@ export type MatchResponse = CredentialsMatchedResult;
 export type MatchRequestHandler = (request: MatchRequest) => Promise<MatchResponse>;
 
 /**
+ * Trust evaluation request from server.
+ * Sent via flow_progress when the backend needs the frontend to evaluate
+ * trust using the AuthZEN PDP (via /v1/evaluate and optionally /v1/resolve).
+ */
+export interface TrustEvaluationRequest {
+	flowId: string;
+	/** The subject identifier (client_id for verifiers, issuer URL for issuers) */
+	subjectId: string;
+	/** "credential_verifier" or "credential_issuer" */
+	subjectType: string;
+	/** Cryptographic key material for binding validation (nil for DID schemes) */
+	keyMaterial?: {
+		type: 'x5c' | 'jwk';
+		x5c?: string[];
+		jwk?: unknown;
+	};
+	/** Whether the frontend should resolve a DID document first */
+	requiresResolution?: boolean;
+	/** Signed request JWT (for DID schemes) */
+	requestJwt?: string;
+	/** Additional evaluation context */
+	context?: Record<string, unknown>;
+}
+
+/**
+ * Trust evaluation result to send back to server
+ */
+export interface TrustEvaluationResponse {
+	trusted: boolean;
+	name?: string;
+	logo?: string;
+	framework?: string;
+	reason?: string;
+	metadata?: Record<string, unknown>;
+}
+
+/**
+ * Trust evaluation handler callback type
+ */
+export type TrustEvaluationHandler = (request: TrustEvaluationRequest) => Promise<TrustEvaluationResponse>;
+
+/**
  * Flow action message to send to server
  */
 export interface FlowAction {
@@ -123,6 +165,7 @@ export class WebSocketTransport implements IFlowTransport {
 	private errorCallbacks = new Set<(error: Error) => void>();
 	private signHandlers = new Set<SignRequestHandler>();
 	private matchHandlers = new Set<MatchRequestHandler>();
+	private trustHandlers = new Set<TrustEvaluationHandler>();
 
 	private reconnectAttempts = 0;
 	private maxReconnectAttempts = 5;
@@ -494,6 +537,17 @@ export class WebSocketTransport implements IFlowTransport {
 		return () => this.matchHandlers.delete(handler);
 	}
 
+	/**
+	 * Register a handler for trust evaluation requests from the server.
+	 * When the server needs trust evaluation (verifier or issuer), it sends a
+	 * flow_progress message with trust_evaluation_required. The handler should
+	 * call the AuthZEN PDP (via /v1/evaluate) and return the result.
+	 */
+	onTrustEvaluation(handler: TrustEvaluationHandler): () => void {
+		this.trustHandlers.add(handler);
+		return () => this.trustHandlers.delete(handler);
+	}
+
 	// ===== Internal Methods =====
 
 	private handleMessage(message: ServerMessage): void {
@@ -501,8 +555,13 @@ export class WebSocketTransport implements IFlowTransport {
 		const flowId = (message.flow_id as string) || (message.flowId as string);
 		const { type } = message;
 
-		// Handle progress events separately
+		// Handle progress events — check for trust evaluation requests first
 		if (type === 'progress' || type === 'flow_progress') {
+			const payload = message.payload as Record<string, unknown> | undefined;
+			if (payload?.trust_evaluation_required) {
+				this.handleTrustEvaluationRequest(flowId, payload);
+				return;
+			}
 			this.emitProgress({
 				flowId,
 				stage: (message.step as string) || (message.stage as string),
@@ -701,6 +760,88 @@ export class WebSocketTransport implements IFlowTransport {
 			this.ws.send(JSON.stringify(msg));
 		} catch (err) {
 			logger.error('Failed to send match response:', err);
+		}
+	}
+
+	/**
+	 * Handle a trust evaluation request from a flow_progress message.
+	 * The backend sends this when it needs the frontend to evaluate trust
+	 * using the same TrustEvaluator used by the HTTP proxy path.
+	 */
+	private async handleTrustEvaluationRequest(
+		flowId: string,
+		payload: Record<string, unknown>,
+	): Promise<void> {
+		const rawRequest = payload.request as Record<string, unknown> | undefined;
+		if (!rawRequest?.subject_id) {
+			logger.error('Malformed trust evaluation request: missing subject_id');
+			this.sendTrustResult(flowId, { trusted: false, reason: 'Malformed request' });
+			return;
+		}
+
+		const request: TrustEvaluationRequest = {
+			flowId,
+			subjectId: rawRequest.subject_id as string,
+			subjectType: rawRequest.subject_type as string,
+			keyMaterial: rawRequest.key_material as TrustEvaluationRequest['keyMaterial'],
+			requiresResolution: rawRequest.requires_resolution as boolean | undefined,
+			requestJwt: rawRequest.request_jwt as string | undefined,
+			context: rawRequest.context as Record<string, unknown> | undefined,
+		};
+
+		if (this.trustHandlers.size === 0) {
+			logger.error('No trust handlers registered, cannot evaluate trust');
+			this.sendTrustResult(flowId, { trusted: false, reason: 'No trust handler available' });
+			return;
+		}
+
+		let lastError: Error | null = null;
+		for (const handler of this.trustHandlers) {
+			try {
+				const response = await handler(request);
+				this.sendTrustResult(flowId, response);
+				return;
+			} catch (err) {
+				lastError = err instanceof Error ? err : new Error(String(err));
+				logger.warn('Trust handler failed:', lastError.message);
+			}
+		}
+
+		// All handlers failed — fail closed (untrusted)
+		this.sendTrustResult(flowId, {
+			trusted: false,
+			reason: lastError?.message || 'Trust evaluation failed',
+		});
+	}
+
+	/**
+	 * Send a trust evaluation result back to the server as a flow_action.
+	 */
+	private sendTrustResult(flowId: string, response: TrustEvaluationResponse): void {
+		if (!this.isConnected()) {
+			logger.error('Cannot send trust result: WebSocket not connected');
+			return;
+		}
+
+		const msg = {
+			type: 'flow_action',
+			flow_id: flowId,
+			action: 'trust_result',
+			payload: {
+				trusted: response.trusted,
+				name: response.name ?? '',
+				logo: response.logo ?? '',
+				framework: response.framework ?? '',
+				reason: response.reason ?? '',
+				metadata: response.metadata ?? {},
+			},
+			timestamp: new Date().toISOString(),
+		};
+
+		try {
+			this.ws!.send(JSON.stringify(msg));
+		} catch (err) {
+			logger.error('Failed to send trust result:', err);
 		}
 	}
 

--- a/src/lib/transport/WebSocketTransport.ts
+++ b/src/lib/transport/WebSocketTransport.ts
@@ -782,11 +782,10 @@ export class WebSocketTransport implements IFlowTransport {
 		}
 
 		const SUPPORTED_SUBJECT_TYPES = ['credential_verifier', 'credential_issuer'] as const;
-		type SupportedSubjectType = (typeof SUPPORTED_SUBJECT_TYPES)[number];
 		const rawSubjectType = rawRequest.subject_type;
 		if (
 			!rawSubjectType ||
-			!SUPPORTED_SUBJECT_TYPES.includes(rawSubjectType as SupportedSubjectType)
+			!SUPPORTED_SUBJECT_TYPES.includes(rawSubjectType as (typeof SUPPORTED_SUBJECT_TYPES)[number])
 		) {
 			logger.error('Malformed trust evaluation request: missing or unknown subject_type', {
 				subject_type: rawSubjectType,

--- a/src/lib/transport/types/TrustTypes.ts
+++ b/src/lib/transport/types/TrustTypes.ts
@@ -1,10 +1,10 @@
 /**
  * Shared trust evaluation types used across OID4VCI and OID4VP flows.
  *
- * Trust evaluation is performed server-side by the wallet backend, which
- * delegates to an AuthZEN PDP (Policy Decision Point). The frontend never
- * performs its own trust evaluation — it displays the result provided by
- * the backend.
+ * Trust evaluation is delegated to an AuthZEN PDP (Policy Decision Point)
+ * via the wallet backend's /v1/evaluate endpoint. Both the HTTP proxy and
+ * WebSocket transports use the same frontend-side TrustEvaluator interface
+ * to call this endpoint.
  *
  * The tri-state `TrustStatus` distinguishes:
  * - `'trusted'`   — PDP evaluated and approved the entity


### PR DESCRIPTION
## Summary

Both HTTP proxy and WebSocket transports now use the same `TrustEvaluator` interface for verifier and issuer trust evaluation. No trust evaluation is performed server-side — all trust decisions go through the frontend's AuthZEN client.

## Problem

Previously, the WebSocket transport path had no client-side trust evaluation. The backend was expected to handle trust evaluation server-side, which violated the architectural requirement that both transports use the same `TrustEvaluator` interface.

## Solution

When the backend sends a `flow_progress` message with `trust_evaluation_required: true`:

1. **WebSocketTransport** intercepts the progress message before emitting it
2. Parses the `TrustEvaluationRequest` from the payload
3. Dispatches to registered trust handlers
4. Sends the result back as a `flow_action` with `action: 'trust_result'`

The **useWebSocketTrustHandler** hook wires the existing `TrustEvaluator` into this handler:

- Parses `client_id_scheme` from context (`did`, `x509_san_dns`, `https`, `pre-registered`)
- For `credential_verifier`: calls `createTrustEvaluator()` → `/v1/evaluate`
- For `credential_issuer`: calls `createIssuerTrustEvaluator()` → `/v1/evaluate`
- For DID schemes with `requires_resolution`: resolves via `createDIDResolver()` → `/v1/resolve`

## Files Changed

| File | Change |
|------|--------|
| `WebSocketTransport.ts` | Trust handler types, registration, message interception, result sending |
| `FlowTransportContext.tsx` | `registerTrustHandler` in context value |
| `useWebSocketTrustHandler.ts` | **New** — Hook wiring TrustEvaluator to WS transport |
| `WebSocketTrustHandlerProvider.tsx` | **New** — Provider component for the hook |
| `AppProvider.tsx` | Mount `WebSocketTrustHandlerProvider` |
| `TrustTypes.ts` | Fix incorrect comment about frontend trust evaluation |

## Testing

- TypeScript compilation passes (no new errors)
- Follows established handler pattern (same as `useWebSocketSignHandler` / `WebSocketSignHandlerProvider`)