### PR TITLE
fix: check if is multi tenant before filtering users and return correct `buildPath` method outside of tenant context

### DIFF
--- a/src/context/TenantContext.tsx
+++ b/src/context/TenantContext.tsx
@@ -139,7 +139,7 @@ export function useTenant(): TenantContextValue {
 				console.warn('switchTenant called outside TenantProvider');
 			},
 			clearTenant: clearStoredTenant,
-			buildPath: (subPath?: string) => buildTenantRoutePath(storedTenant, subPath),
+			buildPath: (subPath?: string) => subPath ? `/${subPath}` : '/',
 		};
 	}
 	return context;

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -277,6 +277,10 @@ export function getTenantFromUrlPath(): string | null {
  * - If tenantId is defined: show matching users AND legacy users (no tenant info for backwards compatibility)
  */
 export function filterUsersByTenantID(tenantId: string | undefined, users: CachedUser[]): CachedUser[] {
+	if (!isMultiTenant()) {
+		return users;
+	}
+	
 	return users.filter((user) => {
 		const userTenantId = user.tenant?.id;
 

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -280,7 +280,7 @@ export function filterUsersByTenantID(tenantId: string | undefined, users: Cache
 	if (!isMultiTenant()) {
 		return users;
 	}
-	
+
 	return users.filter((user) => {
 		const userTenantId = user.tenant?.id;
 


### PR DESCRIPTION
Needed for single tenant deployments.