### PR TITLE
fix: nginx csp header connect-src rule should allow WALLET_ENGINE_URL and allow websocket scheme

### DIFF
--- a/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
+++ b/nginx/docker-entrypoint.d/nginx-security-headers-config.sh
@@ -4,6 +4,7 @@ set -e
 # Available options from environment variables:
 # - NGINX_SEC_HEADER_FILE (Default: "/etc/nginx/conf.d/security-headers.conf")
 # - WS_URL
+# - WALLET_ENGINE_URL
 # - WALLET_BACKEND_URL
 # - OHTTP_KEY_CONFIG
 # - OHTTP_RELAY
@@ -21,6 +22,12 @@ CONNECT_SRC="'self' data:"
 # -------------------------------------------------------------------------------------------------
 if [ -n "${WS_URL}" ]; then
 	CONNECT_SRC="${CONNECT_SRC} ${WS_URL}"
+	CONNECT_SRC="${CONNECT_SRC} $(echo "${WS_URL}" | sed 's|^wss://|https://|;s|^ws://|http://|')"
+fi
+
+if [ -n "${WALLET_ENGINE_URL}" ]; then
+	CONNECT_SRC="${CONNECT_SRC} ${WALLET_ENGINE_URL}"
+	CONNECT_SRC="${CONNECT_SRC} $(echo "${WALLET_ENGINE_URL}" | sed 's|^https://|wss://|;s|^http://|ws://|')"
 fi
 
 if [ -n "${WALLET_BACKEND_URL}" ]; then


### PR DESCRIPTION
Both WS_URL and WALLET_ENGINE_URL could communicate over http(s) and ws(s). We should support this in the CSP policy
