### PR TITLE
chore: remove unused `VALIDATE_CREDENTIALS_WITH_TRUST_ANCHORS` flag

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,7 +39,6 @@ WEBAUTHN_RPID=localhost
 OPENID4VCI_PROOF_TYPE_PRECEDENCE="attestation,jwt"
 OPENID4VP_SAN_DNS_CHECK=false
 OPENID4VP_SAN_DNS_CHECK_SSL_CERTS=false
-VALIDATE_CREDENTIALS_WITH_TRUST_ANCHORS=true
 # Delegate trust evaluation to backend AuthZEN proxy (default: true, recommended)
 # Setting to false only allowed in development mode for local certificate pinning
 DELEGATE_TRUST_TO_BACKEND=true

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Our Web Wallet provides a range of features tailored to enhance the credential m
   - `OPENID4VCI_PROOF_TYPE_PRECEDENCE`: Proof type precedence for OID4VCI (e.g., `"attestation,jwt"`).
   - `OPENID4VP_SAN_DNS_CHECK`: Verify at the OID4VP incoming authorization request that the SAN contained in the certificate is the same with the response_uri (`true` or `false`).
   - `OPENID4VP_SAN_DNS_CHECK_SSL_CERTS`: Flag to switch (`true` or `false`) the Subject Alternative Name validation of the certificates during the OpenID4VP.
-  - `VALIDATE_CREDENTIALS_WITH_TRUST_ANCHORS`: Flag to switch (`true` or `false`) the validation of issued credentials with the registered trust anchors that were defined in the wallet-backend-server.
   - `MULTI_LANGUAGE_DISPLAY`: Enable or disable multi-language support (`true` or `false`). If left empty, it will be handled as `false`.
   - `STATIC_PUBLIC_URL`: The installation's public url.
   - `STATIC_NAME`: The installation's public name.

--- a/config/config.ts
+++ b/config/config.ts
@@ -41,7 +41,6 @@ export const ClientEnvConfigSchema = z.object({
 	OPENID4VCI_PROOF_TYPE_PRECEDENCE: z.string().optional(),
 	OPENID4VP_SAN_DNS_CHECK: z.string().optional(),
 	OPENID4VP_SAN_DNS_CHECK_SSL_CERTS: z.string().optional(),
-	VALIDATE_CREDENTIALS_WITH_TRUST_ANCHORS: z.string().optional(),
 	DELEGATE_TRUST_TO_BACKEND: z.string().optional(),
 	MULTI_LANGUAGE_DISPLAY: z.string().optional(),
 	FOLD_EVENT_HISTORY_AFTER_SECONDS: z.string().optional(),

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,6 @@ export const LOGIN_WITH_PASSWORD: boolean = config.login_with_password ? JSON.pa
 export const WEBAUTHN_RPID = config.webauthn_rpid ?? "localhost";
 export const OPENID4VP_SAN_DNS_CHECK = config.openid4vp_san_dns_check ? config.openid4vp_san_dns_check === 'true' : false;
 export const OPENID4VP_SAN_DNS_CHECK_SSL_CERTS = config.openid4vp_san_dns_check_ssl_certs ? config.openid4vp_san_dns_check_ssl_certs === 'true' : false;
-export const VALIDATE_CREDENTIALS_WITH_TRUST_ANCHORS = config.validate_credentials_with_trust_anchors ? config.validate_credentials_with_trust_anchors  === 'true' : false;
 
 /**
  * Delegate trust evaluation to the backend's AuthZEN proxy.


### PR DESCRIPTION
The env flag is not consumed anywhere in the application, so we remove it for clarity
