### PR TITLE
Fix spelling of "verifiable"

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -220,7 +220,7 @@
 	"pageCredentials": {
 		"addCard": {
 			"text": "Add New Credential",
-			"title": "Verifable Credential"
+			"title": "Verifiable Credential"
 		},
 		"copyDatasetToClipboard": "Copy Dataset (JSON) to clipboard",
 		"credentialDetailsTitle": "Click to view details for {{friendlyName}}",


### PR DESCRIPTION
The other day, I noticed that the "Add New Credential" card on the
wallet "start page" ("Credentials") has the title "Verifable Credential"
which is... not the right spelling.
