### PR TITLE
fix/tenant id in websocket url

### DIFF
--- a/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
@@ -23,8 +23,8 @@ class MockWebSocket {
 
 	sentMessages: string[] = [];
 
-	constructor(url: string) {
-		this.url = url;
+	constructor(url: string | URL) {
+		this.url = typeof url === 'string' ? url : url.toString();
 		// Simulate async connection based on shouldFail flag
 		setTimeout(() => {
 			if (MockWebSocket.shouldFail) {
@@ -77,7 +77,7 @@ beforeEach(() => {
 	MockWebSocket.shouldFail = false; // Reset to success mode
 	// @ts-expect-error - mocking WebSocket
 	globalThis.WebSocket = class extends MockWebSocket {
-		constructor(url: string) {
+		constructor(url: string | URL) {
 			super(url);
 			mockWebSocketInstances.push(this);
 		}

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -191,7 +191,8 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 		this.connectionPromise = new Promise((resolve, reject) => {
 			try {
 				// Connect using the base WebSocket URL; send auth token in a message after connection
-				const url = this.wsUrl;
+				const url = new URL(this.wsUrl);
+				url.searchParams.set('tenant_id', this.tenantId);
 				this.ws = new WebSocket(url);
 
 				this.ws.onopen = () => {
@@ -202,7 +203,6 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 								JSON.stringify({
 									type: 'handshake',
 									app_token: this.authToken,
-									tenantId: this.tenantId
 								})
 							);
 						}


### PR DESCRIPTION
- **fix: set the tenant id in the websocket url as a query parameter to get around the fact that we cant set the X-Tenant-ID header for routing purposes**
- **tests: fix tests failing as result of previous commit**
