### PR TITLE
feat: hocs provider component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import UpdateNotification from './components/Notifications/UpdateNotification';
 import CredentialDetails from './pages/Home/CredentialDetails';
 import { TenantProvider } from './context/TenantContext';
 import { isMultiTenant } from './lib/tenant';
+import { HocProvider } from './HocProvider';
 
 const lazyWithDelay = (importFunction, delay = 1000) => {
 	return React.lazy(() =>
@@ -71,10 +72,13 @@ const PublicRouteWrapper = () => {
 function App() {
 	const multiTenant = useMemo(() => isMultiTenant(), []);
 	const routeWrapper = useMemo(
-		() => (multiTenant
-			? <TenantProvider><Outlet /></TenantProvider>
-			: <Outlet />
-		),
+		() => {
+			const wrapper = <HocProvider><Outlet /></HocProvider>;
+
+			return multiTenant
+				? <TenantProvider>{wrapper}</TenantProvider>
+				: wrapper;
+		},
 		[multiTenant],
 	);
 	const basePath = useMemo(

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -18,10 +18,6 @@ import { WebSocketSignHandlerProvider } from './context/WebSocketSignHandlerProv
 import { ErrorDialogContextProvider } from './context/ErrorDialogContextProvider';
 import { TxCodeInputProvider } from './context/TxCodeInputContext';
 
-// Hocs
-import { UriHandlerProvider } from './hocs/UriHandlerProvider';
-import { NativeWrapperProvider } from './hocs/NativeWrapperProvider';
-
 type RootProviderProps = {
 	children: ReactNode;
 };
@@ -34,24 +30,20 @@ const AppProvider: React.FC<RootProviderProps> = ({ children }) => {
 					<OIDFlowTransportProviderWrapper>
 						<WebSocketSignHandlerProvider>
 							<I18nextProvider i18n={i18n}>
-										<ErrorDialogContextProvider>
-											<OpenID4VPContextProvider>
-												<OpenID4VCIContextProvider>
-													<TxCodeInputProvider>
-														<NotificationProvider>
-															<UriHandlerProvider>
-																<AppSettingsProvider>
-																	<NativeWrapperProvider>
-																		{children}
-																	</NativeWrapperProvider>
-																</AppSettingsProvider>
-															</UriHandlerProvider>
-														</NotificationProvider>
-													</TxCodeInputProvider>
-												</OpenID4VCIContextProvider>
-											</OpenID4VPContextProvider>
-										</ErrorDialogContextProvider>
-									</I18nextProvider>
+								<ErrorDialogContextProvider>
+									<OpenID4VPContextProvider>
+										<OpenID4VCIContextProvider>
+											<TxCodeInputProvider>
+												<NotificationProvider>
+													<AppSettingsProvider>
+														{children}
+													</AppSettingsProvider>
+												</NotificationProvider>
+											</TxCodeInputProvider>
+										</OpenID4VCIContextProvider>
+									</OpenID4VPContextProvider>
+								</ErrorDialogContextProvider>
+							</I18nextProvider>
 						</WebSocketSignHandlerProvider>
 					</OIDFlowTransportProviderWrapper>
 				</CredentialsContextProvider>

--- a/src/HocProvider.tsx
+++ b/src/HocProvider.tsx
@@ -1,0 +1,11 @@
+import React, { PropsWithChildren } from 'react';
+import { UriHandlerProvider } from './hocs/UriHandlerProvider';
+import { NativeWrapperProvider } from './hocs/NativeWrapperProvider';
+
+export const HocProvider: React.FC<PropsWithChildren> = ({ children }) => (
+	<UriHandlerProvider>
+		<NativeWrapperProvider>
+			{children}
+		</NativeWrapperProvider>
+	</UriHandlerProvider>
+);


### PR DESCRIPTION
Create a separate provider component for hocs. This is necessary so we can use them inside `App.tsx`, inside `<TenantProvider/>` (if multitenancy mode). We make a separate component for consistency. We might want to consider refactoring these into contexts instead.

This change solves the scenario when the redirect uri is not to the correct /cb path, the UriHandlerComponent corrects it to /cb. However if in multi-tenancy mode it needs to live inside `<TenantProvider/>` in order to get the right path (since tenants are path scoped)