### PR TITLE
fix: make sure mainKey exists before assuming keystore is open

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -251,14 +251,22 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		[idb, clearGlobalUserHandleB64u, clearGlobalTabId, clearPrivateData, setCalculatedWalletState, userHandleB64u],
 	);
 
+	const isKeystoreOpen = useCallback((): false | [EncryptedContainer, BufferSource] => {
+		if (privateData && mainKey) {
+			return [privateData, mainKey];
+		}
+
+		return false;
+	}, [privateData, mainKey]);
+
 	const assertKeystoreOpen = useCallback(async (): Promise<[EncryptedContainer, CryptoKey]> => {
-		const pd = privateDataRef.current ?? privateData;
-		const mk = mainKeyRef.current ?? mainKey;
-		if (pd && mk) {
+		const openedKeystore = isKeystoreOpen();
+		if (openedKeystore) {
+			const [pd, mk] = openedKeystore;
 			return [pd, await keystore.importMainKey(mk)];
 		}
 		throw new Error("Key store is closed.", { cause: 'keystore_closed' });
-}, [privateData, mainKey]);
+	}, [privateData, mainKey]);
 
 	useOnUserInactivity(close, config.INACTIVE_LOGOUT_MILLIS);
 
@@ -368,7 +376,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			);
 			let newEncryptedContainer: keystore.EncryptedContainer;
 
-			if (privateData) { // keystore is already opened
+			if (isKeystoreOpen()) { // keystore is already opened
 				const [localPrivateData, localMainKey] = await assertKeystoreOpen();
 				const [remoteContainer, remoteMainKey,] = await keystore.openPrivateData(unlockSuccess.mainKey, unlockSuccess.privateData);
 				const [localContainer, ,] = await keystore.openPrivateData(localMainKey, localPrivateData);


### PR DESCRIPTION
We do this by introducing a new function `isKeystoreOpen` which checks and returns privateData and mainKey if both exist. This function is then used both by `assertKeystoreOpen()` and on L379 to check if keystore is open.

This should fix the bug described in #114
