### PR TITLE
fix: isKeystoreOpen should first check `privateData` and `mainKey` refs

### DIFF
--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -252,8 +252,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const isKeystoreOpen = useCallback((): false | [EncryptedContainer, BufferSource] => {
-		const pd = privateDataRef.current ?? privateData;
-		const mk = mainKeyRef.current ?? mainKey;
+		const pd = privateDataRef.current === undefined ? privateData : privateDataRef.current;
+		const mk = mainKeyRef.current === undefined ? mainKey : mainKeyRef.current;
 		if (pd && mk) {
 			return [pd, mk];
 		}

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -252,8 +252,10 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const isKeystoreOpen = useCallback((): false | [EncryptedContainer, BufferSource] => {
-		if (privateData && mainKey) {
-			return [privateData, mainKey];
+		const pd = privateDataRef.current ?? privateData;
+		const mk = mainKeyRef.current ?? mainKey;
+		if (pd && mk) {
+			return [pd, mk];
 		}
 
 		return false;
@@ -266,7 +268,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 			return [pd, await keystore.importMainKey(mk)];
 		}
 		throw new Error("Key store is closed.", { cause: 'keystore_closed' });
-	}, [privateData, mainKey]);
+	}, [isKeystoreOpen]);
 
 	useOnUserInactivity(close, config.INACTIVE_LOGOUT_MILLIS);
 
@@ -471,7 +473,7 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 		tabId,
 		writePrivateDataOnIdb,
 		assertKeystoreOpen,
-		privateData,
+		isKeystoreOpen,
 	]);
 
 


### PR DESCRIPTION
## Summary
`isKeystoreOpen()` reads `privateData` and `mainKey` from closure-captured React state. When back-to-back keystore operations occurred within the same render cycle, the second operation read stale state from before the first operation's commit, resulting in 0 keypairs and a failed presentation.

We fix this by first reading from the refs, which I introduced to previously solve this same issue. 

I am not sure this is the optimal solution but it seems to work well enough, and solves the issue at hand.

## The longer story
In the WebSocket VCI flow, two operations happen within one React render cycle:

1. **`generate_proof`** -> generates a keypair, commits it via `editPrivateData` -> `setPrivateData(B)` updates the ref synchronously but React state updates asynchronously
2. **`flow_complete`** -> `handleReceivedCredentials` runs, `credentialsToStore` gets a valid `kid` (derived from the credential's `cnf.jwk`), then calls `keystore.addCredentials(credentialsToStore)`

Inside `addCredentials`, `openPrivateData()` -> `assertKeystoreOpen()` -> `isKeystoreOpen()` reads the wallet's encrypted container. **Without refs**, it reads the stale React state (container **A**, no keypair). The credential is then stored into a wallet state snapshot that lacks the keypair. 
When `updateWalletState` merges `...walletStateContainer` over `...privateData`, the keypair from step 1 is overwritten/lost.

The keypair the KID references gets erased because `addCredentials` rebuilt the wallet state from a stale snapshot.

## Type of change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## How to test
1. Issue a credential with this patch (vc issuer)
2. Try to verify it (vc verifier)
3. Verification should succeed.
4. To reproduce the error, do the same things without this patch. Verification should fail.

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

## Notes for reviewers
- I would like input on the approach of using refs in the LocalStorageKeystore. Is there a reason we do not want this?
