### PR TITLE
ci: fix security workflow crashing

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Clean Yarn cache
         run: yarn cache clean
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --cache-folder /tmp/yarn-cache
       - name: Run audit
         run: yarn audit --level high || true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+      - name: Clean Yarn cache
+        run: yarn cache clean
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Run audit


### PR DESCRIPTION
The security workflow repeatedly runs into corrupt cache issues. Here we clear the cache each time
