### PR TITLE
feat: ws oid4vp mdoc signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.3",
+    "wallet-common": "git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.4",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.1.6",
     "uuid": "^9.0.0",
     "vite-plugin-pwa": "^0.21.1",
-    "wallet-common": "git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.4",
+    "wallet-common": "git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.5",
     "web-vitals": "^2.1.4",
     "workbox-core": "^7.3.0",
     "workbox-expiration": "^7.3.0",

--- a/src/hooks/useWebSocketSignHandler.ts
+++ b/src/hooks/useWebSocketSignHandler.ts
@@ -19,6 +19,9 @@ import { logger } from '@/logger';
 import type { ProofObject } from '@/lib/openid-flow/transports/OIDFlowWebSocketTransport';
 import { OPENID4VCI_PROOF_TYPE_PRECEDENCE } from '@/config';
 import { applySelectiveDisclosure } from '@/lib/sd-jwt/sd-jwt';
+import { base64url } from 'jose';
+import { buildMdocPresentationDefinition, parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
+import { detectCredentialFormat, VerifiableCredentialFormat } from 'wallet-common';
 
 /**
  * Hook that registers a sign handler with the WebSocket transport.
@@ -109,7 +112,7 @@ export function useWebSocketSignHandler(): void {
 			}
 
 			case 'sign_presentation': {
-				const { audience, nonce, credentialsToInclude } = request.params;
+				const { audience, nonce, credentialsToInclude, responseUri, mdocNonce } = request.params;
 				if (!audience || !nonce) {
 					throw new Error('Missing audience or nonce for presentation signing');
 				}
@@ -117,29 +120,54 @@ export function useWebSocketSignHandler(): void {
 					throw new Error('No credentials to include in presentation');
 				}
 
-				const vpTokens: string[] = [];
 				const vpTokenMap: Record<string, string[]> = {};
 				for (const c of credentialsToInclude) {
 					if (!c.credentialRaw) {
 						throw new Error(`Credential not in cache: ${c.credentialId}`);
 					}
 
-					const credential = await applySelectiveDisclosure(c.credentialRaw, c.disclosedClaims ?? []);
+					let vpToken: string;
 
-					const { vpjwt } = await keystore.signJwtPresentation(
-						nonce,
-						audience,
-						[credential],
-					);
+					switch (detectCredentialFormat(c.credentialRaw)) {
+						case VerifiableCredentialFormat.DC_SDJWT:
+						case VerifiableCredentialFormat.VC_SDJWT:
+						case VerifiableCredentialFormat.JWT_VC_JSON: {
+							const credential = await applySelectiveDisclosure(c.credentialRaw, c.disclosedClaims ?? []);
+							const { vpjwt } = await keystore.signJwtPresentation(nonce, audience, [credential]);
+							vpToken = vpjwt;
+							break;
+						}
+						case VerifiableCredentialFormat.MSO_MDOC: {
+							if (!responseUri || !mdocNonce) {
+								throw new Error('Missing responseUri or mdocNonce for mdoc presentation');
+							}
 
-					vpTokens.push(vpjwt);
+							const mdoc = parseIssuerSignedToMDoc(c.credentialRaw);
+							const presentationDefinition = buildMdocPresentationDefinition(
+								mdoc.documents[0].docType,
+								c.disclosedClaims ?? [],
+							);
 
-					if (c.credentialQueryId) {
-						vpTokenMap[c.credentialQueryId] = [vpjwt];
+							const { deviceResponseMDoc } = await keystore.generateDeviceResponse(
+								mdoc, presentationDefinition, mdocNonce, nonce, audience, responseUri,
+							);
+
+							vpToken = base64url.encode(new Uint8Array(deviceResponseMDoc.encode()));
+							break;
+						}
+						default: {
+							throw new Error('Unsupported credential format for presentation signing');
+						}
 					}
+
+					if (!c.credentialQueryId) {
+						throw new Error(`Missing credentialQueryId for credential: ${c.credentialId}`);
+					}
+
+					vpTokenMap[c.credentialQueryId] = [vpToken];
 				}
 
-				logger.debug(`[WS Sign Handler] Signed ${vpTokens.length} VP JWT(s)`);
+				logger.debug(`[WS Sign Handler] Signed VP token(s) for ${Object.keys(vpTokenMap).length} query/queries`);
 
 				return {
 					vpToken: JSON.stringify(vpTokenMap)

--- a/src/hooks/useWebSocketSignHandler.ts
+++ b/src/hooks/useWebSocketSignHandler.ts
@@ -142,6 +142,11 @@ export function useWebSocketSignHandler(): void {
 								throw new Error('Missing responseUri for mdoc presentation');
 							}
 
+							if (!c.disclosedClaims?.length) {
+								throw new Error('disclosedClaims required for mdoc presentation');
+							}
+
+
 							const mdoc = parseIssuerSignedToMDoc(c.credentialRaw);
 							const presentationDefinition = buildMdocPresentationDefinition(
 								mdoc.documents[0].docType,

--- a/src/hooks/useWebSocketSignHandler.ts
+++ b/src/hooks/useWebSocketSignHandler.ts
@@ -112,7 +112,7 @@ export function useWebSocketSignHandler(): void {
 			}
 
 			case 'sign_presentation': {
-				const { audience, nonce, credentialsToInclude, responseUri, mdocNonce } = request.params;
+				const { audience, nonce, credentialsToInclude, responseUri, verifierJwkThumbprint } = request.params;
 				if (!audience || !nonce) {
 					throw new Error('Missing audience or nonce for presentation signing');
 				}
@@ -138,8 +138,8 @@ export function useWebSocketSignHandler(): void {
 							break;
 						}
 						case VerifiableCredentialFormat.MSO_MDOC: {
-							if (!responseUri || !mdocNonce) {
-								throw new Error('Missing responseUri or mdocNonce for mdoc presentation');
+							if (!responseUri) {
+								throw new Error('Missing responseUri for mdoc presentation');
 							}
 
 							const mdoc = parseIssuerSignedToMDoc(c.credentialRaw);
@@ -149,7 +149,8 @@ export function useWebSocketSignHandler(): void {
 							);
 
 							const { deviceResponseMDoc } = await keystore.generateDeviceResponse(
-								mdoc, presentationDefinition, mdocNonce, nonce, audience, responseUri,
+								mdoc, presentationDefinition, nonce, audience, responseUri,
+								verifierJwkThumbprint ?? null,
 							);
 
 							vpToken = base64url.encode(new Uint8Array(deviceResponseMDoc.encode()));

--- a/src/lib/mdoc/mdoc.ts
+++ b/src/lib/mdoc/mdoc.ts
@@ -1,0 +1,59 @@
+import { base64url } from 'jose';
+import { cborDecode, cborEncode } from '@auth0/mdl/lib/cbor';
+import { parse } from '@auth0/mdl';
+
+/**
+ * Parse a base64url-encoded issuerSigned blob into an MDoc
+ * @todo This partially exists in wallet-common, we should look into consolidating this logic.
+ *
+ * @param raw - Base64url-encoded issuerSigned blob from an OID4VCI proof or similar
+ * @returns Parsed MDoc object with version, documents array, and status
+ */
+export function parseIssuerSignedToMDoc(raw: string) {
+	const credentialBytes = base64url.decode(raw);
+	const issuerSigned = cborDecode(credentialBytes);
+	const issuerAuth = issuerSigned.get('issuerAuth') as Array<Uint8Array>;
+	const payload = issuerAuth?.[2];
+	const docType = cborDecode(payload).data.get('docType');
+	const envelope = {
+		version: '1.0',
+		documents: [new Map([['docType', docType], ['issuerSigned', issuerSigned]])],
+		status: 0,
+	};
+
+	return parse(cborEncode(envelope));
+}
+
+/**
+ * Build a PEX presentation definition from disclosed claim URN paths
+ * @todo This partially exists in wallet-common, we should look into consolidating this logic.
+ *
+ * @param docType - The docType of the MDoc being requested (e.g. "org.iso.18013.5.1.mDL")
+ * @param disclosedClaims - Array of claim paths to disclose, e.g. ["credentialSubject.name", "credentialSubject.address.street"]
+ * @returns Presentation definition object for requesting an MDoc presentation with the specified claims disclosed
+ */
+export function buildMdocPresentationDefinition(docType: string, disclosedClaims: string[]) {
+	const fields = disclosedClaims.map(claim => {
+		const lastDot = claim.lastIndexOf('.');
+		return {
+			path: [`$['${claim.substring(0, lastDot)}']['${claim.substring(lastDot + 1)}']`],
+			intent_to_retain: false,
+		};
+	});
+
+	return {
+		id: 'mdoc-request',
+		input_descriptors: [{
+			id: docType,
+			format: {
+				mso_mdoc: {
+					alg: ['ES256', 'ES384', 'EdDSA'],
+				},
+			},
+			constraints: {
+				limit_disclosure: 'required',
+				fields,
+			},
+		}],
+	};
+}

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -78,7 +78,7 @@ export interface SignRequest {
 			credentialRaw?: string;
 		}>;
 		responseUri?: string;
-		mdocNonce?: string;
+		verifierJwkThumbprint?: string;
 	};
 }
 
@@ -802,7 +802,7 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 				proofTypesSupported: rawParams.proof_types_supported as SignRequest['params']['proofTypesSupported'],
 				count: rawParams.count as number | undefined,
 				responseUri: rawParams.response_uri as string | undefined,
-				mdocNonce: rawParams.mdoc_nonce as string | undefined,
+				verifierJwkThumbprint: rawParams.verifier_jwk_thumbprint as string | undefined,
 				credentialsToInclude: (
 					rawParams.credentials_to_include as Array<{
 						credential_id: string;

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -77,6 +77,8 @@ export interface SignRequest {
 			disclosedClaims?: string[];
 			credentialRaw?: string;
 		}>;
+		responseUri?: string;
+		mdocNonce?: string;
 	};
 }
 
@@ -799,6 +801,8 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 				proofType: rawParams.proof_type as string | undefined,
 				proofTypesSupported: rawParams.proof_types_supported as SignRequest['params']['proofTypesSupported'],
 				count: rawParams.count as number | undefined,
+				responseUri: rawParams.response_uri as string | undefined,
+				mdocNonce: rawParams.mdoc_nonce as string | undefined,
 				credentialsToInclude: (
 					rawParams.credentials_to_include as Array<{
 						credential_id: string;

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -16,12 +16,13 @@ import { CredentialConfigurationSupported, CredentialOfferSchema, VerifiableCred
 import CredentialsContext from "@/context/CredentialsContext";
 import { WalletStateUtils } from '@/services/WalletStateUtils';
 import { fromBase64Url } from '@/util';
-import { DataItem, parse } from '@auth0/mdl';
-import { cborDecode, cborEncode } from '@auth0/mdl/lib/cbor';
+import { DataItem } from '@auth0/mdl';
+import { cborDecode } from '@auth0/mdl/lib/cbor';
 import { COSEKeyToJWK } from "cose-kit";
 import { IOpenID4VCIClientStateRepository } from '@/lib/interfaces/IOpenID4VCIClientStateRepository';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/logger';
+import { parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
 
 /**
  * Raw tx_code spec from OID4VCI §4.1.1 (snake_case, matching protocol wire format).
@@ -73,19 +74,7 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 			return undefined;
 		}
 		case VerifiableCredentialFormat.MSO_MDOC: {
-			const credentialBytes = fromBase64Url(credential);
-			const issuerSigned = cborDecode(credentialBytes);
-			const dataItem = cborDecode(issuerSigned.get('issuerAuth')[2]);
-			const m = {
-				version: '1.0',
-				documents: [new Map([
-					['docType', dataItem.data.get('docType')],
-					['issuerSigned', issuerSigned]
-				])],
-				status: 0
-			};
-			const encoded = cborEncode(m);
-			const mdocCredential = parse(encoded);
+			const mdocCredential = parseIssuerSignedToMDoc(credential);
 			const p: DataItem = cborDecode(mdocCredential.documents[0].issuerSigned.issuerAuth.payload);
 			const deviceKeyInfo = p.data.get('deviceKeyInfo');
 			const deviceKey = deviceKeyInfo.get('deviceKey');

--- a/src/services/CredentialMatchingService.ts
+++ b/src/services/CredentialMatchingService.ts
@@ -12,10 +12,8 @@
 
 import { ExtendedVcEntity } from '@/context/CredentialsContext';
 import { DcqlQuery, DcqlCredential, DcqlQueryResult } from 'dcql';
-import { base64url } from 'jose';
-import { cborDecode, cborEncode } from '@auth0/mdl/lib/cbor';
-import { parse } from '@auth0/mdl';
 import { logger } from '@/logger';
+import { parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
 
 export interface CredentialMatch {
 	input_descriptor_id: string;
@@ -106,31 +104,14 @@ function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _bat
 
 	if (format === 'mso_mdoc') {
 		try {
-			const credentialBytes = base64url.decode(credential.data);
-			const issuerSigned = cborDecode(credentialBytes);
-			const issuerAuth = issuerSigned.get("issuerAuth") as Array<Uint8Array>;
-			const payload = issuerAuth?.[2];
-			const decodedIssuerAuthPayload = cborDecode(payload);
-			const docType = decodedIssuerAuthPayload.data.get("docType");
-			const envelope = {
-				version: "1.0",
-				documents: [
-					new Map([
-						["docType", docType],
-						["issuerSigned", issuerSigned],
-					]),
-				],
-				status: 0,
-			};
-
-			const mdoc = parse(cborEncode(envelope));
+			const mdoc = parseIssuerSignedToMDoc(credential.data);
 			const [document] = mdoc.documents;
 			const nsName = document.issuerSignedNameSpaces[0];
 			const nsObject = document.getIssuerNameSpace(nsName);
 
 			return {
 				credential_format: 'mso_mdoc',
-				doctype: docType,
+				doctype: document.docType,
 				namespaces: { [nsName]: nsObject },
 				cryptographic_holder_binding: true,
 				_batchId: credential.batchId,

--- a/src/services/CredentialMatchingService.ts
+++ b/src/services/CredentialMatchingService.ts
@@ -106,13 +106,16 @@ function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _bat
 		try {
 			const mdoc = parseIssuerSignedToMDoc(credential.data);
 			const [document] = mdoc.documents;
-			const nsName = document.issuerSignedNameSpaces[0];
-			const nsObject = document.getIssuerNameSpace(nsName);
+
+			const namespaces: Record<string, any> = {};
+			for (const nsName of document.issuerSignedNameSpaces) {
+				namespaces[nsName] = document.getIssuerNameSpace(nsName);
+			}
 
 			return {
 				credential_format: 'mso_mdoc',
 				doctype: document.docType,
-				namespaces: { [nsName]: nsObject },
+				namespaces,
 				cryptographic_holder_binding: true,
 				_batchId: credential.batchId,
 			} as DcqlCredential & { _batchId?: number };

--- a/src/services/LocalStorageKeystore.ts
+++ b/src/services/LocalStorageKeystore.ts
@@ -105,7 +105,11 @@ export interface LocalStorageKeystore {
 		CommitCallback,
 	]>,
 
-	generateDeviceResponse(mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }>,
+	generateDeviceResponse(
+		mdocCredential: MDoc, presentationDefinition: any,
+		nonce: string, clientId: string, responseUri: string,
+		verifierJwkThumbprint: string | null,
+	): Promise<{ deviceResponseMDoc: MDoc }>,
 	generateDeviceResponseWithProximity(mdocCredential: MDoc, presentationDefinition: any, sessionTranscriptBytes: any): Promise<{ deviceResponseMDoc: MDoc }>,
 
 	getCalculatedWalletState(): WalletState | null,
@@ -698,8 +702,8 @@ export function useLocalStorageKeystore(eventTarget: EventTarget): LocalStorageK
 	);
 
 	const generateDeviceResponse = useCallback(
-		async (mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }> => (
-			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential, presentationDefinition, mdocGeneratedNonce, verifierGeneratedNonce, clientId, responseUri)
+		async (mdocCredential: MDoc, presentationDefinition: any, nonce: string, clientId: string, responseUri: string, verifierJwkThumbprint: string | null): Promise<{ deviceResponseMDoc: MDoc }> => (
+			await keystore.generateDeviceResponse(await openPrivateData(), mdocCredential, presentationDefinition, nonce, clientId, responseUri, verifierJwkThumbprint)
 		),
 		[openPrivateData]
 	);

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1244,27 +1244,30 @@ export async function generateKeypairs(
 	return [{ keypairs }, newPrivateData];
 }
 
-export async function generateDeviceResponse([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], mdocCredential: MDoc, presentationDefinition: any, mdocGeneratedNonce: string, verifierGeneratedNonce: string, clientId: string, responseUri: string): Promise<{ deviceResponseMDoc: MDoc }> {
-
-	const getSessionTranscriptBytesForOID4VP = async (clId: string, respUri: string, nonce: string, mdocNonce: string) => cborEncode(
-		DataItem.fromData(
-			[
-				null,
-				null,
-				[
-					await crypto.subtle.digest(
-						'SHA-256',
-						cborEncode([clId, mdocNonce]),
-					),
-					await crypto.subtle.digest(
-						'SHA-256',
-						cborEncode([respUri, mdocNonce]),
-					),
-					nonce
-				]
-			]
-		)
-	);
+export async function generateDeviceResponse(
+	[privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState],
+	mdocCredential: MDoc,
+	presentationDefinition: any,
+	nonce: string,
+	clientId: string,
+	responseUri: string,
+	verifierJwkThumbprint: string | null,
+): Promise<{ deviceResponseMDoc: MDoc }> {
+	const getSessionTranscriptBytesForOID4VP = async (
+		clId: string, nonce: string, respUri: string, jwkThumbprint: string | null,
+	) => {
+		const handoverInfo = [
+			clId,
+			nonce,
+			jwkThumbprint ? jose.base64url.decode(jwkThumbprint) : null,
+			respUri,
+		];
+		const handoverInfoHash = new Uint8Array(
+			await crypto.subtle.digest('SHA-256', cborEncode(handoverInfo)),
+		);
+		const handover = ["OpenID4VPHandover", handoverInfoHash];
+		return cborEncode(DataItem.fromData([null, null, handover]));
+	};
 	// extract the COSE device public key from mdoc
 	const p: DataItem = cborDecode(mdocCredential.documents[0].issuerSigned.issuerAuth.payload);
 	const deviceKeyInfo = p.data.get('deviceKeyInfo');
@@ -1289,9 +1292,9 @@ export async function generateDeviceResponse([privateData, mainKey, calculatedSt
 
 	const sessionTranscriptBytes = await getSessionTranscriptBytesForOID4VP(
 		clientId,
+		nonce,
 		responseUri,
-		verifierGeneratedNonce,
-		mdocGeneratedNonce
+		verifierJwkThumbprint,
 	);
 
 	logger.debug("Session transcript bytes created, length:", sessionTranscriptBytes.byteLength);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,9 +7541,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.3":
+"wallet-common@git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.4":
   version "0.0.1"
-  resolved "git+https://github.com/sirosfoundation/wallet-common.git#f50ed5d6a88dc2b47eec0586b6137815cc160515"
+  resolved "git+https://github.com/sirosfoundation/wallet-common.git#ba99113479debbcd594af8f63e0220e6c6ef3524"
   dependencies:
     "@auth0/mdl" "^2.2.0"
     "@sd-jwt/core" "^0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7541,9 +7541,9 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-"wallet-common@git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.4":
+"wallet-common@git+https://github.com/sirosfoundation/wallet-common.git#v0.5.0-sirosid.5":
   version "0.0.1"
-  resolved "git+https://github.com/sirosfoundation/wallet-common.git#ba99113479debbcd594af8f63e0220e6c6ef3524"
+  resolved "git+https://github.com/sirosfoundation/wallet-common.git#f0c0acd9fcd6d75d1f3c01adca3d1f420e0b5e41"
   dependencies:
     "@auth0/mdl" "^2.2.0"
     "@sd-jwt/core" "^0.10.0"


### PR DESCRIPTION
## Summary
We introduce support for mdoc signing in the websocket vp flow.
This PR contains some new mdoc related utilities as well as a updated version of wallet-common.
I've as far as possible tried to keep things the way they worked in the proxy flow.

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Changes
- **deps: pin wallet-common v0.5.0-sirosid.4**
- **feat: introduce mdoc parsing helpers**
- **feat: mdoc signing support**

## Architecture decisions
- We should revisit this to clean up some of the utility functions, as well as unify a lot of them, in wallet-common. But since we need this now, we should probably take the cleanup as a separate task.

## How to test
Run through the WB ITB.


## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)
