### PR TITLE
fix: :latest follows sirosid semver tags, add :latest-build for commit tracking

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -46,9 +46,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.lowercaser.outputs.name }}
           tags: |
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ contains(github.ref, '-sirosid.') }}
             type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
             type=sha,prefix=unstable-,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
+            type=raw,value=latest-build,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
 
       - name: "Build and push Docker image"
         uses: "docker/build-push-action@v5"

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - 'v*.*.**'
       - 'v*.*.**-sirosid.*'
+  pull_request:
+    branches:
+      - release/sirosid
 
 env:
   REGISTRY: "ghcr.io"
@@ -45,6 +48,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.lowercaser.outputs.name }}
           tags: |
+            type=ref,event=pr
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=latest,enable=${{ contains(github.ref, '-sirosid.') }}
             type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
@@ -58,4 +62,4 @@ jobs:
           context: "."
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## Summary

Standardize Docker image tagging policy:

- **`:latest`** now only applied on `v*-sirosid.*` tag pushes (not all semver tags)
- **`:latest-build`** added — follows the latest commit on `release/*` branches
- Preserves existing `unstable` and `unstable-<sha>` tags for `release/sirosid` branch

## Rationale

Previously `:latest` was applied on any semver tag push. Now it specifically tracks sirosid releases, which is the production variant. `:latest-build` provides a stable tag for the newest build from release branches.