### PR TITLE
feat: add @conformance PR comment trigger

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,40 @@
+# Trigger conformance tests via @conformance in a PR comment.
+# See https://developers.siros.org/howto/running-conformance-tests
+#
+# Prerequisites:
+#   - CONFORMANCE_DISPATCH_TOKEN secret: fine-grained PAT with Contents
+#     read/write on sirosfoundation/siros-conformance (to trigger repository_dispatch)
+
+name: Conformance Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  trigger-conformance:
+    runs-on: ubuntu-latest
+    # Only run on PR comments from org members/collaborators starting with @conformance
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@conformance') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    steps:
+      - name: Trigger conformance tests
+        uses: sirosfoundation/siros-conformance/.github/actions/trigger-conformance@main
+        with:
+          comment-body: ${{ github.event.comment.body }}
+          dispatch-token: ${{ secrets.CONFORMANCE_DISPATCH_TOKEN }}
+          github-token: ${{ github.token }}
+          repo: ${{ github.repository }}
+          pr-number: ${{ github.event.issue.number }}
+          comment-id: ${{ github.event.comment.id }}


### PR DESCRIPTION
Adds the `@conformance` PR comment trigger workflow, enabling conformance tests to be dispatched from any PR.

**Usage:** Post a comment on any PR:
```
@conformance              # run wallet profile (auto-detected)
@conformance wallet       # explicit profile
@conformance wallet-frontend:pr-42  # with image override
```

Tests run in [siros-conformance](https://github.com/sirosfoundation/siros-conformance) and results are posted back as a PR comment.

**Prerequisite:** `CONFORMANCE_DISPATCH_TOKEN` secret (already configured).