### PR TITLE
feat: add initial docker-bake functionality

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,14 @@
+group "default" {
+  targets = ["wallet-frontend"]
+}
+
+target "docker-metadata-action" {}
+
+target "wallet-frontend" {
+  inherits = ["docker-metadata-action"]
+}
+
+target "release" {
+  inherits = ["docker-metadata-action"]
+  platforms = ["linux/amd64", "linux/arm64"]
+}


### PR DESCRIPTION
docker-bake is like docker-compose but for Dockerfiles, with a lot of extra features. Here comes an initial variant with support for the docker-metadata github action (copied from sirosid-dashboard).