### PR TITLE
fix: include holder JWK in KB-JWT protected header

### DIFF
--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1178,6 +1178,8 @@ export async function signJwtPresentation([privateData, mainKey, calculatedState
 	);
 	const sdJwt = verifiableCredentials[0];
 	const sd_hash = toBase64Url(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(sdJwt)));
+	// Build a public-key-only JWK for the KB-JWT header (strip any private key material)
+	const { d: _, ...publicJwk } = cnf.jwk as JWK & { d?: string };
 	const kbJWT = await new SignJWT({
 		nonce,
 		aud: audience,
@@ -1186,7 +1188,8 @@ export async function signJwtPresentation([privateData, mainKey, calculatedState
 	}).setIssuedAt()
 		.setProtectedHeader({
 			typ: "kb+jwt",
-			alg: alg
+			alg: alg,
+			jwk: publicJwk,
 		})
 		.sign(importedPrivateKey);
 


### PR DESCRIPTION
## Problem

The WE BUILD ITB verifier (UAegean) rejects our SD-JWT VP presentations with:

```
error: key_binding_jwk_missing
errorDescription: Key Binding JWT protected header is missing jwk.
```

## Root Cause

The KB-JWT protected header only includes `typ` and `alg`, but the verifier expects the holder's public key (`jwk`) in the header for direct signature verification.

RFC 9901 §4.3 only **requires** `typ` and `alg`, but many verifiers — including the WE BUILD ITB suite — check for `jwk` in the KB-JWT header.

## Fix

Add the holder's public key (`cnf.jwk`, with private key material stripped) to the KB-JWT protected header:

```typescript
const { d: _, ...publicJwk } = cnf.jwk as JWK & { d?: string };
.setProtectedHeader({
    typ: "kb+jwt",
    alg: alg,
    jwk: publicJwk,
})
```

The `d` (private key) parameter is explicitly stripped before embedding.