### PR TITLE
ci: migrate to reusable Docker workflow with PR builds

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,4 +1,4 @@
-name: "Create and publish container images"
+name: Build and Publish Docker Image
 
 on:
   push:
@@ -6,55 +6,25 @@ on:
       - release/sirosid
       - release/sirosid/**
     tags:
-      - 'v*.*.**'
-      - 'v*.*.**-sirosid.*'
-
-env:
-  REGISTRY: "ghcr.io"
-  NAME: "${{ github.repository }}"
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  pull_request:
+    branches:
+      - release/sirosid
 
 jobs:
-  "build-and-push-image":
-    runs-on: "ubuntu-24.04"
+  docker:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
     permissions:
-      contents: "read"
-      packages: "write"
-
-    steps:
-      # GHCR doesn't accept uppercase characters in repository path \_o_/
-      - name: "Extract lowercase image name"
-        id: "lowercaser"
-        run: "echo \"name=${NAME}\" | tr '[[:upper:]]' '[[:lower:]]' >> \"${GITHUB_OUTPUT}\""
-
-      - name: "Checkout repository"
-        uses: "actions/checkout@v4"
-
-      - name: "Setup Buildx for Docker"
-        uses: "docker/setup-buildx-action@ba31df4664624f17e1b1ef1c9c85ed1ca9463a6d"
-
-      - name: "Log in to the Container registry"
-        uses: "docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1"
-        with:
-          registry: "${{ env.REGISTRY }}"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: "Extract metadata for Docker"
-        id: "meta"
-        uses: "docker/metadata-action@v5"
-        with:
-          images: ${{ env.REGISTRY }}/${{ steps.lowercaser.outputs.name }}
-          tags: |
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
-            type=sha,prefix=unstable-,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
-
-      - name: "Build and push Docker image"
-        uses: "docker/build-push-action@v5"
-        with:
-          file: "Dockerfile"
-          context: "."
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
+      contents: read
+      packages: write
+      security-events: write
+    with:
+      image-name: sirosfoundation/wallet-frontend
+      platforms: linux/amd64
+      push-pr-images: true
+      tags: |
+        type=semver,pattern={{version}}
+        type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+        type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
+        type=sha,prefix=unstable-,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
+        type=ref,event=pr


### PR DESCRIPTION
Replaces the inline Docker build/publish workflow (50 lines) with a call to the org reusable workflow (20 lines).

## Changes
- **Trivy CVE scanning**: scans every built image, results in Security tab
- **VEX support**: org-level + repo-level CVE suppression
- **PR builds**: org-member PRs get images pushed as `pr-<N>` tags
- **Tag policy preserved**: `unstable` on release/sirosid, semver on tags, `latest` on release tags

## Review notes
- The Dockerfile build uses `--mount=type=secret` for the env file — verify this still works with the reusable workflow's `docker/build-push-action@v7`
- The build includes Node.js runtime packages (tsx, sharp, jsdom) in the nginx stage — Trivy will report their CVEs
- Platform is linux/amd64 only (no arm64 needed for frontend deployment)

cc @leifj