### PR TITLE
fix: patch `@auth0/mdl` `cbor-x`

### DIFF
--- a/patches/@auth0+mdl++cbor-x+1.6.4.patch
+++ b/patches/@auth0+mdl++cbor-x+1.6.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@auth0/mdl/node_modules/cbor-x/decode.js b/node_modules/@auth0/mdl/node_modules/cbor-x/decode.js
+index 580a132..b051f03 100644
+--- a/node_modules/@auth0/mdl/node_modules/cbor-x/decode.js
++++ b/node_modules/@auth0/mdl/node_modules/cbor-x/decode.js
+@@ -44,7 +44,7 @@ let inlineObjectReadThreshold = 2;
+ var BlockedFunction // we use search and replace to change the next call to BlockedFunction to avoid CSP issues for
+ // no-eval build
+ try {
+-	new Function('')
++	new BlockedFunction('')
+ } catch(error) {
+ 	// if eval variants are not supported, do not create inline object readers ever
+ 	inlineObjectReadThreshold = Infinity


### PR DESCRIPTION
We don't allow `eval` operations, which means we've had to patch the `cbor-x` package. Turns out there was a 2nd copy of this hiding in the `@auth0/mdl` package.