### PR TITLE
fix: don't follow redirect_uri from direct_post response

### DIFF
--- a/src/hooks/useOID4VPFlow.ts
+++ b/src/hooks/useOID4VPFlow.ts
@@ -456,14 +456,6 @@ export function useOID4VPFlow(options: UseOID4VPFlowOptions = {}): UseOID4VPFlow
 					currentVcEntityList
 				);
 
-				// Check result type
-				if (result && 'url' in result && result.url) {
-					return {
-						success: true,
-						redirectUri: result.url,
-					};
-				}
-
 				if (result && 'presentation_during_issuance_session' in result) {
 					return {
 						success: true,

--- a/src/lib/services/OpenID4VP/OpenID4VP.ts
+++ b/src/lib/services/OpenID4VP/OpenID4VP.ts
@@ -169,8 +169,12 @@ export function useOpenID4VP({
 			if (responseData.presentation_during_issuance_session) {
 				return { presentation_during_issuance_session: responseData.presentation_during_issuance_session };
 			}
+			// Intentionally ignore redirect_uri from the direct_post response.
+			// The browser's /authorize page handles the redirect to the RP via
+			// polling. If the wallet also follows redirect_uri, both race to
+			// consume the authorization code and the second arrival fails.
 			if (responseData.redirect_uri) {
-				return { url: responseData.redirect_uri };
+				logger.debug('Ignoring redirect_uri from direct_post response (browser handles redirect via polling)');
 			}
 		} catch (err) {
 			logger.error(err);

--- a/src/pages/OpenIDFlowCallback/OpenIDFlowCallback.tsx
+++ b/src/pages/OpenIDFlowCallback/OpenIDFlowCallback.tsx
@@ -422,10 +422,6 @@ const OpenID4VPFlow: OpenIDFlowCallbackHandler = ({ callbackUrl }) => {
 				description: t('openIdCallback.sendResponseSuccess.description'),
 			});
 		}
-
-		if ('redirectUri' in sendResult) {
-			window.location.href = sendResult.redirectUri;
-		}
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
Fixes #159

## Problem

After sending a VP token via `direct_post`, the wallet follows the `redirect_uri` returned in the 200 JSON response. The browser's `/authorize` page also redirects to the same URL via polling. Both race to consume the same authorization code — the second arrival gets an error.

This is the wallet-side counterpart of [SUNET/vc#484](https://github.com/SUNET/vc/issues/484), fixed server-side in [SUNET/vc#485](https://github.com/SUNET/vc/pull/485).

## Fix

- **`OpenID4VP.ts`**: Stop returning `redirect_uri` from `sendAuthorizationResponse()`. Log it and continue.
- **`useOID4VPFlow.ts`**: Remove the `redirectUri` result mapping.
- **`OpenIDFlowCallback.tsx`**: Remove `window.location.href = sendResult.redirectUri`.

The wallet now shows a success message after a successful direct_post submission instead of redirecting to the RP callback.

## Scenario Analysis

All OIDC flow scenarios work correctly with this change because the `/authorize` page (with its polling loop) is **always** present before the wallet is invoked:

| Scenario | Browser | Wallet | Redirect handled by |
|---|---|---|---|
| **Cross-device QR** (phone + desktop) | Tab on desktop polls `/poll/<session_id>` | Phone shows success | Browser poll → RP redirect ✓ |
| **Same browser, different tabs** | Tab A polls | Tab B shows success | Tab A poll → RP redirect ✓ |
| **Same device, deep link** | Original tab polls (opened before deep link) | Wallet tab shows success | Original tab poll → RP redirect ✓ |
| **Credential display** (`ShowCredentialDetails`) | N/A | N/A | Still returns internal `/verification/display/` URI (not the RP callback) — unaffected ✓ |
| **DC API** | N/A | N/A | Not yet implemented — unaffected ✓ |

The key invariant: in the OIDC authorization code flow, the RP always redirects to the verifier's `/authorize` endpoint first. This renders the page that starts polling. The wallet is only invoked afterward (via QR code or deep link), so the polling tab is always active.