### PR TITLE
feat: use `@sirosfoundation/wcc-types` for WalletCompanion client API types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@hpke/core": "^1.7.4",
     "@hpke/dhkem-x25519": "^1.6.4",
     "@sd-jwt/core": "^0.10.0",
+    "@sirosfoundation/wcc-types": "^0.1.0-beta.1",
     "asn1js": "^3.0.5",
     "axios": "^1.4.0",
     "color-convert": "^3.1.3",

--- a/src/context/WalletCompanionContext.tsx
+++ b/src/context/WalletCompanionContext.tsx
@@ -1,35 +1,13 @@
 import { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react';
+import { type WalletCompanionInterface } from '@sirosfoundation/wcc-types';
 import {
 	WALLET_COMPANION_INTEGRATION,
 	I18N_WALLET_NAME_OVERRIDE,
 	STATIC_PUBLIC_URL
 } from '@/config';
 
-type WalletRegistrationInput = {
-	name: string;
-	url: string;
-	icon?: string | null;
-	logo?: string | null;
-	description?: string | null;
-	color?: string | null;
-	protocols?: string[] | null;
-}
-
-type WalletRegistrationResult =  {
-	success: boolean;
-	alreadyRegistered: boolean;
-}
-
-type WalletCompanionAPI = {
-	readonly version: string;
-	readonly isInstalled: boolean;
-	readonly supportedProtocols: readonly string[];
-	registerWallet(walletInfo: WalletRegistrationInput): Promise<WalletRegistrationResult>;
-	isWalletRegistered(url: string): Promise<boolean>;
-}
-
 type WalletCompanionContextValue = {
-	api: WalletCompanionAPI | null;
+	api: WalletCompanionInterface | null;
 	isRegistered: boolean;
 	isLoading: boolean;
 	register: () => Promise<void>;
@@ -38,8 +16,8 @@ type WalletCompanionContextValue = {
 const WalletCompanionContext = createContext<WalletCompanionContextValue | null>(null);
 
 export const WalletCompanionProvider = ({ children }: { children: ReactNode }) => {
-	const [api] = useState<WalletCompanionAPI | null>(
-		() => (window as any).WalletCompanion ?? null
+	const [api] = useState<WalletCompanionInterface | null>(
+		() => window.WalletCompanion ?? null
 	);
 
 	const [isRegistered, setIsRegistered] = useState(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2328,6 +2328,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
+"@sirosfoundation/wcc-types@^0.1.0-beta.1":
+  version "0.1.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@sirosfoundation/wcc-types/-/wcc-types-0.1.0-beta.1.tgz#972c6fdf250e5286990f6e3a05a6c75551f818c6"
+  integrity sha512-nmLval2+yG1/rJUpjiaZlJoykxuMSndq7tpTYmy2XMAEuC3/ANoboG4VyFh7stf7vHMdAObE+jRkxLSg8VARVw==
+
 "@stablelib/binary@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/binary/-/binary-1.0.1.tgz#c5900b94368baf00f811da5bdb1610963dfddf7f"


### PR DESCRIPTION
We import the types instead of re-declaring them in the frontend.