### PR TITLE
fix: render `<Spinner />` instead of nothing when credential engine hasn't loaded

### DIFF
--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -9,6 +9,7 @@ import { logger } from '../logger';
 import { BACKEND_URL } from '@/config';
 import { getTenantFromUrlPath } from '@/lib/tenant';
 import { useHttpClient } from '@/hooks/useHttpClient';
+import Spinner from '@/components/Shared/Spinner';
 
 type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
@@ -218,7 +219,7 @@ export const CredentialsContextProvider = ({ children }: React.PropsWithChildren
 
 	if (isLoggedIn && !credentialEngine) {
 		return (
-			<></>
+			<Spinner />
 		);
 	}
 	else {


### PR DESCRIPTION
## Summary
Currently, before the `credentialEngine` is initialized, there is no UI rendered. This is now more noticable with the new `/v1/resolve` calls.

Instead, in this PR we render a loading screen, which is nicer UX.

Ideally this would be fixed by allowing children to render and then wait for `credentialEngine` to be available, but we will look into this as a separate task

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Related issues / tickets
- Fixes #163

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

## Security checklist
<!-- For any PR that touches code, dependencies, or configuration -->
- [x] No secrets, credentials, or API keys are hardcoded
- [x] New dependencies have been reviewed for known vulnerabilities
- [x] User input is validated and sanitized where applicable
- [x] No new attack surface introduced without security review
- [x] PII/sensitive data handling follows data protection policies
- [ ] N/A — this PR does not affect code, deps, or configuration

## Notes for reviewers
<!-- Risk areas, review order, follow-ups, rollout plan -->
- ...
