### PR TITLE
Feature/mdoc parsing

### DIFF
--- a/src/lib/mdoc/mdoc.ts
+++ b/src/lib/mdoc/mdoc.ts
@@ -11,17 +11,9 @@ import { parse } from '@auth0/mdl';
  */
 export function parseIssuerSignedToMDoc(raw: string) {
 	const credentialBytes = base64url.decode(raw);
-	const issuerSigned = cborDecode(credentialBytes);
-	const issuerAuth = issuerSigned.get('issuerAuth') as Array<Uint8Array>;
-	const payload = issuerAuth?.[2];
-	const docType = cborDecode(payload).data.get('docType');
-	const envelope = {
-		version: '1.0',
-		documents: [new Map([['docType', docType], ['issuerSigned', issuerSigned]])],
-		status: 0,
-	};
-
-	return parse(cborEncode(envelope));
+	const deviceResponse = cborDecode(credentialBytes);
+	const parsed =  parse(cborEncode(deviceResponse));
+	return parsed;
 }
 
 /**

--- a/src/lib/mdoc/mdoc.ts
+++ b/src/lib/mdoc/mdoc.ts
@@ -11,9 +11,16 @@ import { parse } from '@auth0/mdl';
  */
 export function parseIssuerSignedToMDoc(raw: string) {
 	const credentialBytes = base64url.decode(raw);
-	const deviceResponse = cborDecode(credentialBytes);
-	const parsed =  parse(cborEncode(deviceResponse));
-	return parsed;
+	const issuerSigned = cborDecode(credentialBytes);
+	const issuerAuth = issuerSigned.get('issuerAuth') as Array<Uint8Array>;
+	const payload = issuerAuth?.[2];
+	const docType = cborDecode(payload).data.get('docType');
+	const envelope = {
+		version: '1.0',
+		documents: [new Map([['docType', docType], ['issuerSigned', issuerSigned]])],
+		status: 0,
+	};
+	return parse(cborEncode(envelope));
 }
 
 /**

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -15,13 +15,13 @@ import { CredentialConfigurationSupported, CredentialOfferSchema, VerifiableCred
 import CredentialsContext from "@/context/CredentialsContext";
 import { WalletStateUtils } from '@/services/WalletStateUtils';
 import { fromBase64Url } from '@/util';
-import { DataItem } from '@auth0/mdl';
 import { cborDecode } from '@auth0/mdl/lib/cbor';
 import { COSEKeyToJWK } from "cose-kit";
 import { IOpenID4VCIClientStateRepository } from '@/lib/interfaces/IOpenID4VCIClientStateRepository';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/logger';
 import { useHttpClient } from '@/hooks/useHttpClient';
+import { parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
 
 /**
  * Raw tx_code spec from OID4VCI §4.1.1 (snake_case, matching protocol wire format).
@@ -74,9 +74,14 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 			const credentialBytes = fromBase64Url(credential);
 			const mdoc = cborDecode(credentialBytes);
 			const mdocDocument = mdoc.get("documents");
-			const issuerSigned = mdocDocument[0].get('issuerSigned');
-			const issuerAuth = issuerSigned.get('issuerAuth');
-			const msoBinaryRaw = issuerAuth[2];
+			const msoBinaryRaw = (() => {
+				if (mdocDocument) {
+					const issuerSigned = mdocDocument[0].get('issuerSigned');
+					const issuerAuth = issuerSigned.get('issuerAuth');
+					return issuerAuth[2];
+				}
+				return parseIssuerSignedToMDoc(credential);
+			})();
 			let msoBinary;
 			if (msoBinaryRaw instanceof Uint8Array) {
 				msoBinary = msoBinaryRaw;

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -80,9 +80,8 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 					const issuerAuth = issuerSigned.get('issuerAuth');
 					return issuerAuth[2];
 				}
-				const mdocDcument = parseIssuerSignedToMDoc(credential);
-				const issuerSigned = mdocDcument[0].get('issuerSigned');
-				const issuerAuth = issuerSigned.get('issuerAuth');
+
+				const issuerAuth = mdoc.get('issuerAuth');
 				return issuerAuth[2];
 			})();
 			let msoBinary;

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -21,7 +21,6 @@ import { COSEKeyToJWK } from "cose-kit";
 import { IOpenID4VCIClientStateRepository } from '@/lib/interfaces/IOpenID4VCIClientStateRepository';
 import { useNavigate } from 'react-router-dom';
 import { logger } from '@/logger';
-import { parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
 import { useHttpClient } from '@/hooks/useHttpClient';
 
 /**
@@ -51,38 +50,43 @@ const openid4vciProofTypePrecedence = config.OPENID4VCI_PROOF_TYPE_PRECEDENCE.sp
 
 const textDecoder = new TextDecoder();
 
-
-export const deriveHolderKidFromCredential = async (credential: string, format: VerifiableCredentialFormat): Promise<string | undefined> => {
-	switch (format) {
-		case VerifiableCredentialFormat.VC_SDJWT:
-		case VerifiableCredentialFormat.DC_SDJWT:
-		case VerifiableCredentialFormat.JWT_VC_JSON: {
-			const payload = credential.split('.')[1];
-			if (!payload) {
-				return undefined;
-			}
-
-			try {
-				const decoded = JSON.parse(textDecoder.decode(fromBase64Url(payload)));
-				const cnf = decoded.cnf as { jwk?: jose.JWK } | undefined;
-				if (cnf?.jwk) {
-					return jose.calculateJwkThumbprint(cnf.jwk, "sha256");
-				}
-			} catch {
-				return undefined;
-			}
-			return undefined;
-		}
-		case VerifiableCredentialFormat.MSO_MDOC: {
-			const mdocCredential = parseIssuerSignedToMDoc(credential);
-			const p: DataItem = cborDecode(mdocCredential.documents[0].issuerSigned.issuerAuth.payload);
-			const deviceKeyInfo = p.data.get('deviceKeyInfo');
-			const deviceKey = deviceKeyInfo.get('deviceKey');
-			// @ts-ignore
-			const devicePublicKeyJwk = COSEKeyToJWK(deviceKey);
-			return jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
+export const deriveHolderKidFromCredential = async (credential: string, format: string) => {
+	if (format === VerifiableCredentialFormat.VC_SDJWT || format === VerifiableCredentialFormat.DC_SDJWT) {
+		const payload = credential.split('.')[1];
+		const { cnf } = JSON.parse(textDecoder.decode(fromBase64Url(payload)));
+		if (cnf && cnf.jwk) {
+			const jwkThumbprint = await jose.calculateJwkThumbprint(cnf.jwk as jose.JWK, "sha256");
+			return jwkThumbprint;
 		}
 	}
+	else if (format === VerifiableCredentialFormat.MSO_MDOC) {
+		const credentialBytes = fromBase64Url(credential);
+		const mdoc = cborDecode(credentialBytes);
+		const mdocDocument = mdoc.get("documents");
+		const issuerSigned = mdocDocument[0].get('issuerSigned');
+		const issuerAuth = issuerSigned.get('issuerAuth');
+		const msoBinaryRaw = issuerAuth[2];
+		let msoBinary;
+		if (msoBinaryRaw instanceof Uint8Array) {
+			msoBinary = msoBinaryRaw;
+		} else if (msoBinaryRaw instanceof ArrayBuffer) {
+			msoBinary = new Uint8Array(msoBinaryRaw);
+		} else {
+			msoBinary = new Uint8Array(msoBinaryRaw.buffer, msoBinaryRaw.byteOffset || 0, msoBinaryRaw.byteLength || msoBinaryRaw.length);
+		} 
+		if (msoBinary && msoBinary.length > 0) {			
+			try {
+				const msoData = cborDecode(msoBinary);
+				const deviceKeyInfo = msoData.data.get('deviceKeyInfo');
+				const deviceKey = deviceKeyInfo.get('deviceKey');
+				const devicePublicKeyJwk = COSEKeyToJWK(deviceKey);
+				const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
+				return kid;
+			} catch (e) {
+				console.log("Failed to decode MSO:", e);
+			}
+		}
+		}
 }
 
 export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopup, openID4VCIClientStateRepository }: { errorCallback: (title: string, message: string) => void, showPopupConsent: (options: Record<string, unknown>) => Promise<boolean>, showMessagePopup: (message: { title: string, description: string }) => void, openID4VCIClientStateRepository: IOpenID4VCIClientStateRepository }): IOpenID4VCI {

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -73,14 +73,17 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 		case VerifiableCredentialFormat.MSO_MDOC: {
 			const credentialBytes = fromBase64Url(credential);
 			const mdoc = cborDecode(credentialBytes);
-			const mdocDocument = mdoc.get("documents");
+			const fullMdocDocument = mdoc.get("documents");
 			const msoBinaryRaw = (() => {
-				if (mdocDocument) {
-					const issuerSigned = mdocDocument[0].get('issuerSigned');
+				if (fullMdocDocument) {
+					const issuerSigned = fullMdocDocument[0].get('issuerSigned');
 					const issuerAuth = issuerSigned.get('issuerAuth');
 					return issuerAuth[2];
 				}
-				return parseIssuerSignedToMDoc(credential);
+				const mdocDcument = parseIssuerSignedToMDoc(credential);
+				const issuerSigned = mdocDcument[0].get('issuerSigned');
+				const issuerAuth = issuerSigned.get('issuerAuth');
+				return issuerAuth[2];
 			})();
 			let msoBinary;
 			if (msoBinaryRaw instanceof Uint8Array) {

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -51,42 +51,54 @@ const openid4vciProofTypePrecedence = config.OPENID4VCI_PROOF_TYPE_PRECEDENCE.sp
 const textDecoder = new TextDecoder();
 
 export const deriveHolderKidFromCredential = async (credential: string, format: string) => {
-	if (format === VerifiableCredentialFormat.VC_SDJWT || format === VerifiableCredentialFormat.DC_SDJWT) {
-		const payload = credential.split('.')[1];
-		const { cnf } = JSON.parse(textDecoder.decode(fromBase64Url(payload)));
-		if (cnf && cnf.jwk) {
-			const jwkThumbprint = await jose.calculateJwkThumbprint(cnf.jwk as jose.JWK, "sha256");
-			return jwkThumbprint;
-		}
-	}
-	else if (format === VerifiableCredentialFormat.MSO_MDOC) {
-		const credentialBytes = fromBase64Url(credential);
-		const mdoc = cborDecode(credentialBytes);
-		const mdocDocument = mdoc.get("documents");
-		const issuerSigned = mdocDocument[0].get('issuerSigned');
-		const issuerAuth = issuerSigned.get('issuerAuth');
-		const msoBinaryRaw = issuerAuth[2];
-		let msoBinary;
-		if (msoBinaryRaw instanceof Uint8Array) {
-			msoBinary = msoBinaryRaw;
-		} else if (msoBinaryRaw instanceof ArrayBuffer) {
-			msoBinary = new Uint8Array(msoBinaryRaw);
-		} else {
-			msoBinary = new Uint8Array(msoBinaryRaw.buffer, msoBinaryRaw.byteOffset || 0, msoBinaryRaw.byteLength || msoBinaryRaw.length);
-		} 
-		if (msoBinary && msoBinary.length > 0) {			
+	switch (format) {
+		case VerifiableCredentialFormat.VC_SDJWT:
+		case VerifiableCredentialFormat.DC_SDJWT:
+		case VerifiableCredentialFormat.JWT_VC_JSON: {
+			const payload = credential.split('.')[1];
+			if (!payload) {
+				return undefined;
+			}
 			try {
-				const msoData = cborDecode(msoBinary);
-				const deviceKeyInfo = msoData.data.get('deviceKeyInfo');
-				const deviceKey = deviceKeyInfo.get('deviceKey');
-				const devicePublicKeyJwk = COSEKeyToJWK(deviceKey);
-				const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
-				return kid;
-			} catch (e) {
-				console.log("Failed to decode MSO:", e);
+				const decoded = JSON.parse(textDecoder.decode(fromBase64Url(payload)));
+				const cnf = decoded.cnf as { jwk?: jose.JWK } | undefined;
+				if (cnf?.jwk) {
+					return jose.calculateJwkThumbprint(cnf.jwk, "sha256");
+				}
+			} catch {
+				return undefined;
+			}
+			return undefined;
+		}
+		case VerifiableCredentialFormat.MSO_MDOC: {
+			const credentialBytes = fromBase64Url(credential);
+			const mdoc = cborDecode(credentialBytes);
+			const mdocDocument = mdoc.get("documents");
+			const issuerSigned = mdocDocument[0].get('issuerSigned');
+			const issuerAuth = issuerSigned.get('issuerAuth');
+			const msoBinaryRaw = issuerAuth[2];
+			let msoBinary;
+			if (msoBinaryRaw instanceof Uint8Array) {
+				msoBinary = msoBinaryRaw;
+			} else if (msoBinaryRaw instanceof ArrayBuffer) {
+				msoBinary = new Uint8Array(msoBinaryRaw);
+			} else {
+				msoBinary = new Uint8Array(msoBinaryRaw.buffer, msoBinaryRaw.byteOffset || 0, msoBinaryRaw.byteLength || msoBinaryRaw.length);
+			}
+			if (msoBinary && msoBinary.length > 0) {
+				try {
+					const msoData = cborDecode(msoBinary);
+					const deviceKeyInfo = msoData.data.get('deviceKeyInfo');
+					const deviceKey = deviceKeyInfo.get('deviceKey');
+					const devicePublicKeyJwk = COSEKeyToJWK(deviceKey);
+					const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
+					return kid;
+				} catch (e) {
+					console.log("Failed to decode MSO:", e);
+				}
 			}
 		}
-		}
+	}
 }
 
 export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopup, openID4VCIClientStateRepository }: { errorCallback: (title: string, message: string) => void, showPopupConsent: (options: Record<string, unknown>) => Promise<boolean>, showMessagePopup: (message: { title: string, description: string }) => void, openID4VCIClientStateRepository: IOpenID4VCIClientStateRepository }): IOpenID4VCI {

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -47,7 +47,7 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 					logger.warn(`Schema validation failed for ${credentialIssuerIdentifier}:`, JSON.stringify(parsed.error.issues));
 					return null;
 				}
-				return { metadata: parsed.data };
+				return { metadata: trustMetadata };
 			}
 			catch (err) {
 				logger.error(err);

--- a/src/lib/services/OpenID4VCIHelper.ts
+++ b/src/lib/services/OpenID4VCIHelper.ts
@@ -47,7 +47,7 @@ export function useOpenID4VCIHelper(): IOpenID4VCIHelper {
 					logger.warn(`Schema validation failed for ${credentialIssuerIdentifier}:`, JSON.stringify(parsed.error.issues));
 					return null;
 				}
-				return { metadata: trustMetadata };
+				return { metadata: parsed.data };
 			}
 			catch (err) {
 				logger.error(err);


### PR DESCRIPTION
This update improves the wallet frontend’s handling of mDoc credentials in line with standard used by VC issuer.

Changes :
Added logic to correctly extract the kid (Key ID) from mDoc credentials according to the Verifiable Credential (VC) issuer specification. Updated the parsing flow to support cases where the issuer returns a full device response instead of a minimal credential payload.