### PR TITLE
feat: send OID4VCI §10 credential lifecycle notifications

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,6 +20,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: VITE_CJS_IGNORE_WARNING=true yarn vitest run --coverage
+        env:
+          CI: true
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:
@@ -28,3 +42,7 @@ jobs:
           args: >
             -Dsonar.organization=${{ github.repository_owner }}
             -Dsonar.projectKey=${{ github.repository_owner }}_${{ github.event.repository.name }}
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+            -Dsonar.sources=src
+            -Dsonar.tests=src
+            -Dsonar.test.inclusions=**/__tests__/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/react-dom": "^18.3.1",
     "@types/reflect-metadata": "^0.1.0",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-istanbul": "1.6.1",
     "concurrently": "^9.2.1",
     "depcheck": "^1.4.7",
     "eslint": "^8.56.0",

--- a/patches/test-exclude+6.0.0.patch
+++ b/patches/test-exclude+6.0.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/test-exclude/index.js b/node_modules/test-exclude/index.js
+index 3e99aab..b1d8a4b 100644
+--- a/node_modules/test-exclude/index.js
++++ b/node_modules/test-exclude/index.js
+@@ -3,7 +3,10 @@
+ const path = require('path');
+ const { promisify } = require('util');
+ const glob = promisify(require('glob'));
+-const minimatch = require('minimatch');
++// Support both minimatch v3 (default export is function) and v9+/v10+
++// (named export). The named export is `minimatch.minimatch` in newer versions.
++const _minimatchModule = require('minimatch');
++const minimatch = typeof _minimatchModule === 'function' ? _minimatchModule : _minimatchModule.minimatch;
+ const { defaults } = require('@istanbuljs/schema');
+ const isOutsideDir = require('./is-outside-dir');

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -446,19 +446,20 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 
 	/**
 	 * OID4VCI §10: send credential_accepted notifications for each credential
-	 * that has a notification_id.
+	 * that has a notification_id. Delegates to the transport — each transport
+	 * decides how (or whether) to deliver the notification.
 	 */
 	const sendCredentialNotifications = useCallback((
 		credentials: OID4VCIFlowResult['credentials'],
 		flowId?: string,
 	) => {
-		if (!flowId || transportType !== 'websocket' || !transport) return;
+		if (!flowId || !transport) return;
 		for (const c of credentials ?? []) {
 			if (c.notification_id) {
 				transport.sendCredentialNotification(flowId, c.notification_id, 'credential_accepted');
 			}
 		}
-	}, [transportType, transport]);
+	}, [transport]);
 
 	/**
 	 * Handle received credentials: validate, store in wallet, and notify.

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -49,6 +49,7 @@ export interface UseOID4VCIFlowReturn {
 		credentials: OID4VCIFlowResult['credentials'],
 		credentialIssuerIdentifier?: string,
 		credentialConfigurationId?: string,
+		flowId?: string,
 	) => Promise<OID4VCIFlowResult>;
 	/**
 	 * Current transport type being used
@@ -450,7 +451,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		credentials: OID4VCIFlowResult['credentials'],
 		credentialIssuerIdentifier?: OID4VCIFlowResult['credentialIssuerIdentifier'],
 		credentialConfigurationId?: OID4VCIFlowResult['selectedCredentialConfigurationId'],
-
+		flowId?: OID4VCIFlowResult['flowId'],
 	): Promise<OID4VCIFlowResult> => {
 		setIsLoading(true);
 		setError(null);
@@ -525,6 +526,20 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 
 			notify('newCredential');
 
+			// OID4VCI §10: once credentials are stored, send credential_accepted
+			// notification for each credential that has a notification_id.
+			if (flowId && transportType === 'websocket' && transport) {
+				for (const c of credentials) {
+					if (c.notification_id) {
+						transport.sendCredentialNotification(
+							flowId,
+							c.notification_id,
+							'credential_accepted',
+						);
+					}
+				}
+			}
+
 			return { success: true };
 		} catch (err) {
 			if (abortRef.current.signal.aborted) {
@@ -544,7 +559,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		} finally {
 			setIsLoading(false);
 		}
-	}, [api, keystore,	credentialEngine, onError, onIssuanceWarnings, assertNotAborted]);
+	}, [api, keystore,	credentialEngine, onError, onIssuanceWarnings, assertNotAborted, transportType, transport]);
 
 	return {
 		handleCredentialOffer,

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -10,6 +10,7 @@ import SessionContext from '@/context/SessionContext';
 import { notify } from '@/context/notifier';
 import CredentialsContext from '@/context/CredentialsContext';
 import { logger } from '@/logger';
+import { dispatchCredentialNotifications } from '@/lib/openid-flow/utils/credentialNotifications';
 
 export interface UseOID4VCIFlowOptions {
 	/**
@@ -444,22 +445,10 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		}
 	}, [transportType, transport, openID4VCI, onProgress, onError, assertNotAborted]);
 
-	/**
-	 * OID4VCI §10: send credential_accepted notifications for each credential
-	 * that has a notification_id. Delegates to the transport — each transport
-	 * decides how (or whether) to deliver the notification.
-	 */
 	const sendCredentialNotifications = useCallback((
 		credentials: OID4VCIFlowResult['credentials'],
 		flowId?: string,
-	) => {
-		if (!flowId || !transport) return;
-		for (const c of credentials ?? []) {
-			if (c.notification_id) {
-				transport.sendCredentialNotification(flowId, c.notification_id, 'credential_accepted');
-			}
-		}
-	}, [transport]);
+	) => dispatchCredentialNotifications(transport, credentials, flowId), [transport]);
 
 	/**
 	 * Handle received credentials: validate, store in wallet, and notify.

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -559,7 +559,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		} finally {
 			setIsLoading(false);
 		}
-	}, [api, keystore,	credentialEngine, onError, onIssuanceWarnings, assertNotAborted, transportType, transport]);
+	}, [api, keystore, credentialEngine, onError, onIssuanceWarnings, assertNotAborted, transportType, transport]);
 
 	return {
 		handleCredentialOffer,

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -445,6 +445,22 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 	}, [transportType, transport, openID4VCI, onProgress, onError, assertNotAborted]);
 
 	/**
+	 * OID4VCI §10: send credential_accepted notifications for each credential
+	 * that has a notification_id.
+	 */
+	const sendCredentialNotifications = useCallback((
+		credentials: OID4VCIFlowResult['credentials'],
+		flowId?: string,
+	) => {
+		if (!flowId || transportType !== 'websocket' || !transport) return;
+		for (const c of credentials ?? []) {
+			if (c.notification_id) {
+				transport.sendCredentialNotification(flowId, c.notification_id, 'credential_accepted');
+			}
+		}
+	}, [transportType, transport]);
+
+	/**
 	 * Handle received credentials: validate, store in wallet, and notify.
 	 */
 	const handleReceivedCredentials = useCallback(async (
@@ -528,17 +544,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 
 			// OID4VCI §10: once credentials are stored, send credential_accepted
 			// notification for each credential that has a notification_id.
-			if (flowId && transportType === 'websocket' && transport) {
-				for (const c of credentials) {
-					if (c.notification_id) {
-						transport.sendCredentialNotification(
-							flowId,
-							c.notification_id,
-							'credential_accepted',
-						);
-					}
-				}
-			}
+			sendCredentialNotifications(credentials, flowId);
 
 			return { success: true };
 		} catch (err) {
@@ -559,7 +565,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 		} finally {
 			setIsLoading(false);
 		}
-	}, [api, keystore, credentialEngine, onError, onIssuanceWarnings, assertNotAborted, transportType, transport]);
+	}, [api, keystore, credentialEngine, onError, onIssuanceWarnings, assertNotAborted, sendCredentialNotifications]);
 
 	return {
 		handleCredentialOffer,

--- a/src/lib/openid-flow/__tests__/OIDFlowNotification.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowNotification.test.ts
@@ -1,23 +1,130 @@
 /**
  * Tests for OID4VCI §10 credential notification across transports.
  *
- * Ensures sendCredentialNotification is a safe no-op on the base transport
- * and that the retry decorator delegates correctly.
+ * Covers:
+ * - dispatchCredentialNotifications utility function
+ * - NullOIDFlowTransport.sendCredentialNotification (no-op)
+ * - OIDFlowDirectTransport.sendCredentialNotification (no-op)
+ * - OIDFlowHttpProxyTransport.sendCredentialNotification (no-op)
+ * - OIDFlowTransportWithRetry delegate
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import { OIDFlowTransportWithRetry } from '../decorators/OIDFlowTransportWithRetry';
 import { NullOIDFlowTransport } from '../types/IOIDFlowTransport';
+import { OIDFlowDirectTransport } from '../transports/OIDFlowDirectTransport';
+import { OIDFlowHttpProxyTransport } from '../transports/OIDFlowHttpProxyTransport';
+import { dispatchCredentialNotifications } from '../utils/credentialNotifications';
 
-describe('sendCredentialNotification', () => {
-	it('is a no-op on NullOIDFlowTransport', () => {
+// ─── dispatchCredentialNotifications ──────────────────────────────────────────
+
+describe('dispatchCredentialNotifications', () => {
+	it('is a no-op when transport is null', () => {
+		expect(() => {
+			dispatchCredentialNotifications(null, [{ format: 'vc+sd-jwt', credential: 'eyJ...', notification_id: 'n1' }], 'flow-1');
+		}).not.toThrow();
+	});
+
+	it('is a no-op when transport is undefined', () => {
+		expect(() => {
+			dispatchCredentialNotifications(undefined, [], 'flow-1');
+		}).not.toThrow();
+	});
+
+	it('is a no-op when flowId is undefined', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(transport, [{ format: 'vc+sd-jwt', credential: 'eyJ...', notification_id: 'n1' }], undefined);
+		expect(transport.sendCredentialNotification).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when flowId is empty string', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(transport, [{ format: 'vc+sd-jwt', credential: 'eyJ...', notification_id: 'n1' }], '');
+		expect(transport.sendCredentialNotification).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when credentials is undefined', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(transport, undefined, 'flow-1');
+		expect(transport.sendCredentialNotification).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op when credentials is empty', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(transport, [], 'flow-1');
+		expect(transport.sendCredentialNotification).not.toHaveBeenCalled();
+	});
+
+	it('skips credentials without notification_id', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(
+			transport,
+			[{ format: 'vc+sd-jwt', credential: 'eyJ...' }],
+			'flow-1',
+		);
+		expect(transport.sendCredentialNotification).not.toHaveBeenCalled();
+	});
+
+	it('calls sendCredentialNotification for each credential with notification_id', () => {
+		const transport = { sendCredentialNotification: vi.fn() } as any;
+		dispatchCredentialNotifications(
+			transport,
+			[
+				{ format: 'vc+sd-jwt', credential: 'eyJ1', notification_id: 'notif-1' },
+				{ format: 'vc+sd-jwt', credential: 'eyJ2' },
+				{ format: 'vc+sd-jwt', credential: 'eyJ3', notification_id: 'notif-3' },
+			],
+			'flow-42',
+		);
+		expect(transport.sendCredentialNotification).toHaveBeenCalledTimes(2);
+		expect(transport.sendCredentialNotification).toHaveBeenCalledWith('flow-42', 'notif-1', 'credential_accepted');
+		expect(transport.sendCredentialNotification).toHaveBeenCalledWith('flow-42', 'notif-3', 'credential_accepted');
+	});
+});
+
+// ─── NullOIDFlowTransport ─────────────────────────────────────────────────────
+
+describe('NullOIDFlowTransport.sendCredentialNotification', () => {
+	it('is a no-op and does not throw', () => {
 		const t = new NullOIDFlowTransport();
 		expect(() => {
 			t.sendCredentialNotification('f', 'n', 'credential_accepted');
 		}).not.toThrow();
 	});
+});
 
-	it('delegates through OIDFlowTransportWithRetry', () => {
+// ─── OIDFlowDirectTransport ───────────────────────────────────────────────────
+
+describe('OIDFlowDirectTransport.sendCredentialNotification', () => {
+	it('is a no-op and does not throw', () => {
+		const t = new OIDFlowDirectTransport();
+		expect(() => {
+			t.sendCredentialNotification('flow-1', 'notif-1', 'credential_accepted');
+		}).not.toThrow();
+	});
+});
+
+// ─── OIDFlowHttpProxyTransport ────────────────────────────────────────────────
+
+describe('OIDFlowHttpProxyTransport.sendCredentialNotification', () => {
+	it('is a no-op and does not throw', () => {
+		const mockHttpClient = {
+			get: vi.fn(),
+			post: vi.fn(),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as any;
+		const t = new OIDFlowHttpProxyTransport(mockHttpClient);
+		expect(() => {
+			t.sendCredentialNotification('flow-1', 'notif-1', 'credential_accepted');
+		}).not.toThrow();
+	});
+});
+
+// ─── OIDFlowTransportWithRetry ────────────────────────────────────────────────
+
+describe('OIDFlowTransportWithRetry.sendCredentialNotification', () => {
+	it('delegates to inner transport', () => {
 		const inner = {
 			connect: vi.fn(),
 			disconnect: vi.fn(),

--- a/src/lib/openid-flow/__tests__/OIDFlowNotification.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowNotification.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests for OID4VCI §10 credential notification across transports.
+ *
+ * Ensures sendCredentialNotification is a safe no-op on the base transport
+ * and that the retry decorator delegates correctly.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { OIDFlowTransportWithRetry } from '../decorators/OIDFlowTransportWithRetry';
+import { NullOIDFlowTransport } from '../types/IOIDFlowTransport';
+
+describe('sendCredentialNotification', () => {
+	it('is a no-op on NullOIDFlowTransport', () => {
+		const t = new NullOIDFlowTransport();
+		expect(() => {
+			t.sendCredentialNotification('f', 'n', 'credential_accepted');
+		}).not.toThrow();
+	});
+
+	it('delegates through OIDFlowTransportWithRetry', () => {
+		const inner = {
+			connect: vi.fn(),
+			disconnect: vi.fn(),
+			isConnected: vi.fn(() => true),
+			startOID4VCIFlow: vi.fn(),
+			startOID4VPFlow: vi.fn(),
+			request: vi.fn(),
+			onProgress: vi.fn(() => () => {}),
+			onError: vi.fn(() => () => {}),
+			sendCredentialNotification: vi.fn(),
+		};
+		const retry = new OIDFlowTransportWithRetry(inner as any);
+		retry.sendCredentialNotification('flow-1', 'notif-1', 'credential_accepted');
+		expect(inner.sendCredentialNotification).toHaveBeenCalledWith(
+			'flow-1', 'notif-1', 'credential_accepted',
+		);
+	});
+});

--- a/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
@@ -1093,6 +1093,22 @@ describe('OIDFlowWebSocketTransport', () => {
 			}).not.toThrow();
 		});
 
+		it('should catch and log errors when send throws', async () => {
+			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const mockWs = mockWebSocketInstances[0];
+			// Force send() to throw
+			vi.spyOn(mockWs, 'send').mockImplementation(() => {
+				throw new Error('WebSocket send failed');
+			});
+
+			// Should not propagate the error
+			expect(() => {
+				transport.sendCredentialNotification('flow-123', 'notif-abc', 'credential_accepted');
+			}).not.toThrow();
+		});
+
 		it('should include notification_id in mapped credentials', async () => {
 			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
 			await transport.connect();

--- a/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
@@ -1064,4 +1064,60 @@ describe('OIDFlowWebSocketTransport', () => {
 			expect(sentMessage.payload.selectedCredentials).toHaveLength(1);
 		});
 	});
+
+	describe('Credential Notification', () => {
+		it('should send credential_notification with correct shape', async () => {
+			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			transport.sendCredentialNotification('flow-123', 'notif-abc', 'credential_accepted');
+
+			await vi.waitFor(() => {
+				expect(mockWebSocketInstances[0].sentMessages.length).toBeGreaterThan(1);
+			});
+
+			const sentMessage = JSON.parse(mockWebSocketInstances[0].sentMessages[1]);
+			expect(sentMessage).toEqual({
+				type: 'credential_notification',
+				flow_id: 'flow-123',
+				notification_id: 'notif-abc',
+				event: 'credential_accepted',
+			});
+		});
+
+		it('should be a no-op when not connected', () => {
+			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
+			// Not connected — should not throw
+			transport.sendCredentialNotification('flow-123', 'notif-abc', 'credential_accepted');
+		});
+
+		it('should include notification_id in mapped credentials', async () => {
+			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
+			await transport.connect();
+
+			const flowPromise = transport.startOID4VCIFlow({
+				credentialOfferUri: 'https://issuer.example.com/offer/123',
+			});
+
+			await vi.waitFor(() => {
+				expect(mockWebSocketInstances[0].sentMessages.length).toBeGreaterThan(1);
+			});
+
+			mockWebSocketInstances[0].simulateMessage({
+				type: 'flow_complete',
+				flow_id: JSON.parse(mockWebSocketInstances[0].sentMessages[1]).flow_id,
+				credentials: [
+					{ format: 'vc+sd-jwt', credential: 'eyJ...', notification_id: 'notif-xyz' },
+					{ format: 'vc+sd-jwt', credential: 'eyK...' },
+				],
+			});
+
+			const result = await flowPromise;
+			expect(result.success).toBe(true);
+			expect(result.credentials).toHaveLength(2);
+			expect(result.credentials![0].notification_id).toBe('notif-xyz');
+			expect(result.credentials![1].notification_id).toBeUndefined();
+			expect(result.flowId).toBeDefined();
+		});
+	});
 });

--- a/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
+++ b/src/lib/openid-flow/__tests__/OIDFlowWebSocketTransport.test.ts
@@ -1088,7 +1088,9 @@ describe('OIDFlowWebSocketTransport', () => {
 		it('should be a no-op when not connected', () => {
 			const transport = new OIDFlowWebSocketTransport(wsUrl, authToken);
 			// Not connected — should not throw
-			transport.sendCredentialNotification('flow-123', 'notif-abc', 'credential_accepted');
+			expect(() => {
+				transport.sendCredentialNotification('flow-123', 'notif-abc', 'credential_accepted');
+			}).not.toThrow();
 		});
 
 		it('should include notification_id in mapped credentials', async () => {

--- a/src/lib/openid-flow/decorators/OIDFlowTransportWithRetry.ts
+++ b/src/lib/openid-flow/decorators/OIDFlowTransportWithRetry.ts
@@ -174,6 +174,12 @@ export class OIDFlowTransportWithRetry implements IOIDFlowTransport {
 		}
 	}
 
+	// ===== OID4VCI §10 Notification (delegated) =====
+
+	sendCredentialNotification(flowId: string, notificationId: string, event: string): void {
+		this.transport.sendCredentialNotification(flowId, notificationId, event);
+	}
+
 	// ===== Event Subscriptions (delegated) =====
 
 	onProgress(callback: (event: OIDFlowProgressEvent) => void): () => void {

--- a/src/lib/openid-flow/transports/OIDFlowDirectTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowDirectTransport.ts
@@ -92,19 +92,15 @@ export class OIDFlowDirectTransport implements IOIDFlowTransport {
 		);
 	}
 
+	// ===== OID4VCI §10 Notification =====
+
+	sendCredentialNotification(): void {
+		// No-op: direct transport has no persistent connection for notifications
+	}
+
 	// ===== Event Subscriptions =====
 
 	onProgress(callback: (event: OIDFlowProgressEvent) => void): () => void {
-		this.progressCallbacks.add(callback);
-		return () => this.progressCallbacks.delete(callback);
-	}
-
-	onError(callback: (error: Error) => void): () => void {
-		this.errorCallbacks.add(callback);
-		return () => this.errorCallbacks.delete(callback);
-	}
-
-	// ===== CORS Discovery Methods =====
 
 	/**
 	 * Check if a URL supports CORS from the current origin

--- a/src/lib/openid-flow/transports/OIDFlowDirectTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowDirectTransport.ts
@@ -101,6 +101,14 @@ export class OIDFlowDirectTransport implements IOIDFlowTransport {
 	// ===== Event Subscriptions =====
 
 	onProgress(callback: (event: OIDFlowProgressEvent) => void): () => void {
+		this.progressCallbacks.add(callback);
+		return () => this.progressCallbacks.delete(callback);
+	}
+
+	onError(callback: (error: Error) => void): () => void {
+		this.errorCallbacks.add(callback);
+		return () => this.errorCallbacks.delete(callback);
+	}
 
 	/**
 	 * Check if a URL supports CORS from the current origin

--- a/src/lib/openid-flow/transports/OIDFlowHttpProxyTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowHttpProxyTransport.ts
@@ -137,6 +137,14 @@ export class OIDFlowHttpProxyTransport implements IOIDFlowTransport {
 	// ===== Event Subscriptions =====
 
 	onProgress(callback: (event: OIDFlowProgressEvent) => void): () => void {
+		this.progressCallbacks.add(callback);
+		return () => this.progressCallbacks.delete(callback);
+	}
+
+	onError(callback: (error: Error) => void): () => void {
+		this.errorCallbacks.add(callback);
+		return () => this.errorCallbacks.delete(callback);
+	}
 
 	private emitError(error: Error): void {
 		Array.from(this.errorCallbacks).forEach(callback => {

--- a/src/lib/openid-flow/transports/OIDFlowHttpProxyTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowHttpProxyTransport.ts
@@ -128,19 +128,15 @@ export class OIDFlowHttpProxyTransport implements IOIDFlowTransport {
 		}
 	}
 
+	// ===== OID4VCI §10 Notification =====
+
+	sendCredentialNotification(): void {
+		// No-op: HTTP transport has no persistent connection for notifications
+	}
+
 	// ===== Event Subscriptions =====
 
 	onProgress(callback: (event: OIDFlowProgressEvent) => void): () => void {
-		this.progressCallbacks.add(callback);
-		return () => this.progressCallbacks.delete(callback);
-	}
-
-	onError(callback: (error: Error) => void): () => void {
-		this.errorCallbacks.add(callback);
-		return () => this.errorCallbacks.delete(callback);
-	}
-
-	// ===== Internal Helpers =====
 
 	private emitError(error: Error): void {
 		Array.from(this.errorCallbacks).forEach(callback => {

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -379,6 +379,26 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 		throw new Error('Invalid OID4VCI flow params: no valid entry point or continuation');
 	}
 
+	/**
+	 * Send an OID4VCI §10 credential lifecycle notification to the backend.
+	 * Fire-and-forget over the existing WebSocket connection. The backend
+	 * forwards it to the issuer's notification endpoint using the ephemeral
+	 * issuance credentials retained in memory for the given flow.
+	 */
+	sendCredentialNotification(flowId: string, notificationId: string, event: string): void {
+		if (!this.isConnected()) return;
+		try {
+			this.ws!.send(JSON.stringify({
+				type: 'credential_notification',
+				flow_id: flowId,
+				notification_id: notificationId,
+				event,
+			}));
+		} catch (e) {
+			logger.error('Failed to send credential notification:', e);
+		}
+	}
+
 	private mapOID4VCIResponse(response: ServerMessage): OID4VCIFlowResult {
 		if (response.type === 'error' || response.type === 'flow_error') {
 			return {
@@ -465,7 +485,13 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 		}
 		// Handle credentials array from server
 		if (response?.credentials && Array.isArray(response.credentials)) {
-				result.credentials = (response.credentials as Array<{format: string; credential: string; vct?: string}>);
+			result.credentials = (response.credentials as Array<{format: string; credential: string; vct?: string; notification_id?: string}>);
+		}
+
+		// Flow ID (needed for credential notification)
+		const flowId = (response.flow_id as string) || (response.flowId as string);
+		if (flowId) {
+			result.flowId = flowId;
 		}
 
 		// Deferred

--- a/src/lib/openid-flow/types/IOIDFlowTransport.ts
+++ b/src/lib/openid-flow/types/IOIDFlowTransport.ts
@@ -59,8 +59,8 @@ export interface IOIDFlowTransport {
 	/**
 	 * Send an OID4VCI §10 credential lifecycle notification.
 	 * Fire-and-forget: the backend forwards it to the issuer's notification
-	 * endpoint using ephemeral issuance credentials. Only meaningful for
-	 * transports that maintain a persistent connection (WebSocket).
+	 * endpoint using ephemeral issuance credentials.
+	 * Transports without notification support may no-op.
 	 */
 	sendCredentialNotification(flowId: string, notificationId: string, event: string): void;
 

--- a/src/lib/openid-flow/types/IOIDFlowTransport.ts
+++ b/src/lib/openid-flow/types/IOIDFlowTransport.ts
@@ -54,6 +54,16 @@ export interface IOIDFlowTransport {
 	 */
 	startOID4VCIFlow(params: OID4VCIFlowParams): Promise<OID4VCIFlowResult>;
 
+	// ===== OID4VCI §10 Notification =====
+
+	/**
+	 * Send an OID4VCI §10 credential lifecycle notification.
+	 * Fire-and-forget: the backend forwards it to the issuer's notification
+	 * endpoint using ephemeral issuance credentials. Only meaningful for
+	 * transports that maintain a persistent connection (WebSocket).
+	 */
+	sendCredentialNotification(flowId: string, notificationId: string, event: string): void;
+
 	// ===== OID4VP (Verifiable Presentation) =====
 
 	/**
@@ -112,6 +122,10 @@ export class NullOIDFlowTransport implements IOIDFlowTransport {
 
 	async startOID4VCIFlow(): Promise<OID4VCIFlowResult> {
 		throw new Error('No transport configured');
+	}
+
+	sendCredentialNotification(): void {
+		// No-op: notification requires a connected transport
 	}
 
 	async startOID4VPFlow(): Promise<OID4VPFlowResult> {

--- a/src/lib/openid-flow/types/IOIDFlowTransport.ts
+++ b/src/lib/openid-flow/types/IOIDFlowTransport.ts
@@ -124,7 +124,7 @@ export class NullOIDFlowTransport implements IOIDFlowTransport {
 		throw new Error('No transport configured');
 	}
 
-	sendCredentialNotification(): void {
+	sendCredentialNotification(_flowId: string, _notificationId: string, _event: string): void {
 		// No-op: notification requires a connected transport
 	}
 

--- a/src/lib/openid-flow/types/OID4VCITypes.ts
+++ b/src/lib/openid-flow/types/OID4VCITypes.ts
@@ -128,7 +128,12 @@ export interface OID4VCIFlowResult {
 		format?: string;
 		credential: string;
 		vct?: string;
+		/** OID4VCI §10 notification identifier for lifecycle events */
+		notification_id?: string;
 	}>;
+
+	/** Flow ID from the backend (needed for credential notification) */
+	flowId?: string;
 
 	// ===== Deferred issuance =====
 

--- a/src/lib/openid-flow/utils/credentialNotifications.ts
+++ b/src/lib/openid-flow/utils/credentialNotifications.ts
@@ -1,0 +1,29 @@
+/**
+ * OID4VCI §10 Credential Notification Utilities
+ *
+ * Pure utility functions for dispatching credential lifecycle notifications.
+ * Extracted from useOID4VCIFlow for testability.
+ */
+
+import type { IOIDFlowTransport } from '../types/IOIDFlowTransport';
+import type { OID4VCIFlowResult } from '../types/OID4VCITypes';
+
+/**
+ * Send `credential_accepted` notifications for each credential that carries a
+ * `notification_id`. Delegates to the transport, which decides how (or whether)
+ * to deliver the notification to the issuer.
+ *
+ * This is a pure function — safe to call from hooks, callbacks, or tests.
+ */
+export function dispatchCredentialNotifications(
+	transport: IOIDFlowTransport | null | undefined,
+	credentials: OID4VCIFlowResult['credentials'],
+	flowId?: string,
+): void {
+	if (!flowId || !transport) return;
+	for (const c of credentials ?? []) {
+		if (c.notification_id) {
+			transport.sendCredentialNotification(flowId, c.notification_id, 'credential_accepted');
+		}
+	}
+}

--- a/src/pages/OpenIDFlowCallback/OpenIDFlowCallback.tsx
+++ b/src/pages/OpenIDFlowCallback/OpenIDFlowCallback.tsx
@@ -161,6 +161,7 @@ const OpenID4VCIFlow: OpenIDFlowCallbackHandler = ({ callbackUrl }) => {
 				offer.credentials,
 				offer.credentialIssuerIdentifier,
 				offer.selectedCredentialConfigurationId,
+				offer.flowId,
 			);
 		}
 
@@ -196,6 +197,7 @@ const OpenID4VCIFlow: OpenIDFlowCallbackHandler = ({ callbackUrl }) => {
 				preAuthResult.credentials,
 				preAuthResult.credentialIssuerIdentifier,
 				preAuthResult.selectedCredentialConfigurationId,
+				preAuthResult.flowId,
 			);
 		}
 	};
@@ -213,6 +215,7 @@ const OpenID4VCIFlow: OpenIDFlowCallbackHandler = ({ callbackUrl }) => {
 				result.credentials,
 				result.credentialIssuerIdentifier,
 				result.selectedCredentialConfigurationId,
+				result.flowId,
 			);
 		}
 	};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,5 +24,18 @@ export default defineConfig({
 		typecheck: {
 			enabled: true,
 		},
+		coverage: {
+			provider: 'istanbul',
+			reporter: ['lcov', 'text-summary'],
+			reportsDirectory: './coverage',
+			exclude: [
+				'lib/**',
+				'node_modules/**',
+				'src/lib/openid-flow/__tests__/**',
+				'src/**/__tests__/**',
+				'src/**/*.test.*',
+				'src/**/*.spec.*',
+			],
+		},
 	},
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,10 +99,24 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
+  integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.29.7"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.5", "@babel/compat-data@^7.26.8":
   version "7.26.8"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
+
+"@babel/compat-data@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
+  integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
 "@babel/core@^7.16.0", "@babel/core@^7.21.3", "@babel/core@^7.24.4", "@babel/core@^7.26.0":
   version "7.26.9"
@@ -119,6 +133,27 @@
     "@babel/template" "^7.26.9"
     "@babel/traverse" "^7.26.9"
     "@babel/types" "^7.26.9"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
+"@babel/core@^7.23.9":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
+  integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helpers" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/remapping" "^2.3.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -156,6 +191,17 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
+  integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
+  dependencies:
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.18.6", "@babel/helper-annotate-as-pure@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz#d8eac4d2dc0d7b6e11fa6e535332e0d3184f06b4"
@@ -170,6 +216,17 @@
   dependencies:
     "@babel/compat-data" "^7.26.5"
     "@babel/helper-validator-option" "^7.25.9"
+    browserslist "^4.24.0"
+    lru-cache "^5.1.1"
+    semver "^6.3.1"
+
+"@babel/helper-compilation-targets@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
+  integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
     semver "^6.3.1"
@@ -212,6 +269,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.28.0.tgz#b9430df2aa4e17bc28665eadeae8aa1d985e6674"
   integrity sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==
 
+"@babel/helper-globals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
+  integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
+
 "@babel/helper-member-expression-to-functions@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz#9dfffe46f727005a5ea29051ac835fb735e4c1a3"
@@ -228,6 +290,14 @@
     "@babel/traverse" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/helper-module-imports@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
+  integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
@@ -236,6 +306,15 @@
     "@babel/helper-module-imports" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
     "@babel/traverse" "^7.25.9"
+
+"@babel/helper-module-transforms@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz#b062747a5997ba138637201328bbff77960574ae"
+  integrity sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
 
 "@babel/helper-optimise-call-expression@^7.25.9":
   version "7.25.9"
@@ -285,6 +364,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
@@ -300,10 +384,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz#010b6938fab7cb7df74aa2bbc06aa503b8fe5fb4"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
 
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
+
 "@babel/helper-validator-option@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz#86e45bd8a49ab7e03f276577f96179653d41da72"
   integrity sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==
+
+"@babel/helper-validator-option@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
+  integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
 
 "@babel/helper-wrap-function@^7.25.9":
   version "7.25.9"
@@ -322,6 +416,14 @@
     "@babel/template" "^7.26.9"
     "@babel/types" "^7.26.9"
 
+"@babel/helpers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.7.tgz#45abfde7548997e34376c3e69feb475cffb4a607"
+  integrity sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.20.7", "@babel/parser@^7.26.9":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
@@ -335,6 +437,13 @@
   integrity sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==
   dependencies:
     "@babel/types" "^7.29.0"
+
+"@babel/parser@^7.23.9", "@babel/parser@^7.25.4", "@babel/parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
+  integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
+  dependencies:
+    "@babel/types" "^7.29.7"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.9":
   version "7.25.9"
@@ -1115,6 +1224,15 @@
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
 
+"@babel/template@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.29.7.tgz#4d9d4004f645cdd304de958c725162784ecac700"
+  integrity sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/traverse@^7.23.2":
   version "7.29.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
@@ -1141,6 +1259,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.7.tgz#c47b07a41b95da0907d026b5dd894d98de7d2f2d"
+  integrity sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==
+  dependencies:
+    "@babel/code-frame" "^7.29.7"
+    "@babel/generator" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/parser" "^7.29.7"
+    "@babel/template" "^7.29.7"
+    "@babel/types" "^7.29.7"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.7", "@babel/types@^7.21.3", "@babel/types@^7.25.9", "@babel/types@^7.26.9", "@babel/types@^7.4.4":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
@@ -1148,6 +1279,14 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@babel/types@^7.25.4", "@babel/types@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.7.tgz#8005e31d82712ee7adaef6e23c63b71a62770a92"
+  integrity sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
 
 "@babel/types@^7.28.6", "@babel/types@^7.29.0":
   version "7.29.0"
@@ -1769,6 +1908,11 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
   integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
 
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
+  integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
@@ -1793,7 +1937,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/remapping@^2.3.4":
+"@jridgewell/remapping@^2.3.4", "@jridgewell/remapping@^2.3.5":
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/remapping/-/remapping-2.3.5.tgz#375c476d1972947851ba1e15ae8f123047445aa1"
   integrity sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==
@@ -1829,18 +1973,18 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
-  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.28":
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@jridgewell/trace-mapping@^0.3.28":
-  version "0.3.31"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
-  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
+  integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -2883,6 +3027,21 @@
     "@babel/plugin-transform-react-jsx-source" "^7.25.9"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
+
+"@vitest/coverage-istanbul@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-istanbul/-/coverage-istanbul-1.6.1.tgz#f17e64819a2cbb256fb8454371b9cccd7d757821"
+  integrity sha512-0NWKNPrbMo1s6emwnn+UpGPxrSEd9R6VpQ3wzYz0y43esZjjDkGLb6Qkvfu6LNyQO4TAGyepaZ11imUmmIFLaw==
+  dependencies:
+    debug "^4.3.4"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-instrument "^6.0.1"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^5.0.4"
+    istanbul-reports "^3.1.6"
+    magicast "^0.3.3"
+    picocolors "^1.0.0"
+    test-exclude "^6.0.0"
 
 "@vitest/expect@1.6.1":
   version "1.6.1"
@@ -4800,7 +4959,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4954,6 +5113,11 @@ html-encoding-sniffer@^6.0.0:
   integrity sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==
   dependencies:
     "@exodus/bytes" "^1.6.0"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-parse-stringify@^3.0.1:
   version "3.0.1"
@@ -5318,6 +5482,48 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-instrument@^6.0.1:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.4:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.6:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 iterator.prototype@^1.1.4:
   version "1.1.5"
@@ -5756,6 +5962,22 @@ magic-string@^0.30.5:
   integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
+
+magicast@^0.3.3:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
+  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+  dependencies:
+    "@babel/parser" "^7.25.4"
+    "@babel/types" "^7.25.4"
+    source-map-js "^1.2.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
@@ -6930,7 +7152,7 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-source-map-js@^1.0.1, source-map-js@^1.2.1:
+source-map-js@^1.0.1, source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -7190,6 +7412,15 @@ terser@^5.17.4:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
+
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Summary

After successfully storing a credential received via WebSocket transport, send a `credential_accepted` notification back to the backend for each credential that has a `notification_id`. The backend forwards it to the issuer's notification endpoint using ephemeral issuance credentials.

## What changed

- **OID4VCITypes.ts**: Added `notification_id?` to credentials array type and `flowId?` to `OID4VCIFlowResult`
- **OIDFlowWebSocketTransport.ts**: Stop discarding `notification_id` in type cast; add `sendCredentialNotification()` fire-and-forget method; capture `flowId` from response
- **IOIDFlowTransport.ts**: Added `sendCredentialNotification()` to transport interface (no-op in NullOIDFlowTransport)
- **useOID4VCIFlow.ts**: Accept `flowId` in `handleReceivedCredentials()`; after credential storage, send `credential_accepted` for each credential with a notification_id
- **OpenIDFlowCallback.tsx**: Pass `flowId` through all `handleReceivedCredentials` call sites

## Context

Companion to [go-wallet-backend PR #226](https://github.com/sirosfoundation/go-wallet-backend/pull/226) which implements server-side OID4VCI §10 notification forwarding. Aligns with the Kotlin SDK which already sends notifications via the engine WebSocket session.

## Protocol

```
Issuer → Backend: credential response with notification_id
Backend → Frontend: flow_complete with notification_id in credentials array
Frontend: stores credential
Frontend → Backend: { type: 'credential_notification', flow_id, notification_id, event: 'credential_accepted' }
Backend → Issuer: POST to notification_endpoint with DPoP auth
```

## Testing

All 379 existing tests pass. Functional testing requires running the conformance suite with the updated go-wallet-backend.