### PR TITLE
feat: handle issuer_trust_evaluated progress step

### DIFF
--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -666,12 +666,8 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 
 			// Server-side issuer trust result (informational, no response needed).
 			// The backend evaluated issuer trust directly via go-trust PDP.
-			if (stage === 'trust_evaluated' && payload?.issuer_trust_evaluated) {
-				console.log(
-					`[OID4VP] Server-side issuer trust: trusted=${payload.trusted} ` +
-					`framework=${payload.framework} issuer=${payload.issuer}`
-				);
-			}
+			// No action required — the progress is emitted via emitProgress() below
+			// for UI subscribers to consume.
 
 			if (
 				stage === 'authorization_required' &&

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -664,6 +664,15 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 				await this.handleTrustEvaluationStep(flowId, payload);
 			}
 
+			// Server-side issuer trust result (informational, no response needed).
+			// The backend evaluated issuer trust directly via go-trust PDP.
+			if (stage === 'trust_evaluated' && payload?.issuer_trust_evaluated) {
+				console.log(
+					`[OID4VP] Server-side issuer trust: trusted=${payload.trusted} ` +
+					`framework=${payload.framework} issuer=${payload.issuer}`
+				);
+			}
+
 			if (
 				stage === 'authorization_required' &&
 				(payload?.authorization_url || payload?.pre_authorized_code)


### PR DESCRIPTION
Handle the new server-side issuer trust evaluation result from go-wallet-backend Phase 4. Informational only — no response required. The progress event is emitted via emitProgress() for UI consumption.

Related: sirosfoundation/go-wallet-backend#239