### PR TITLE
ci: add workflow_dispatch and pull_request triggers

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -8,6 +8,19 @@ on:
     tags:
       - 'v*.*.**'
       - 'v*.*.**-sirosid.*'
+  pull_request:
+    branches:
+      - release/sirosid
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (branch, tag, or SHA)'
+        required: false
+        default: 'release/sirosid'
+      image_tag:
+        description: 'Custom image tag (leave empty for standard policy)'
+        required: false
+        default: ''
 
 env:
   REGISTRY: "ghcr.io"
@@ -28,11 +41,14 @@ jobs:
 
       - name: "Checkout repository"
         uses: "actions/checkout@v4"
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || github.ref }}
 
       - name: "Setup Buildx for Docker"
         uses: "docker/setup-buildx-action@ba31df4664624f17e1b1ef1c9c85ed1ca9463a6d"
 
       - name: "Log in to the Container registry"
+        if: github.event_name != 'pull_request'
         uses: "docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1"
         with:
           registry: "${{ env.REGISTRY }}"
@@ -49,6 +65,8 @@ jobs:
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=raw,value=unstable,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
             type=sha,prefix=unstable-,enable=${{ github.ref == 'refs/heads/release/sirosid' }}
+            type=ref,event=pr
+            type=raw,value=${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }},enable=${{ github.event_name == 'workflow_dispatch' && inputs.image_tag != '' }}
 
       - name: "Build and push Docker image"
         uses: "docker/build-push-action@v5"
@@ -57,4 +75,4 @@ jobs:
           context: "."
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Enables manual builds via the Actions UI ('Run workflow' button) and automatic PR build validation for PRs targeting `release/sirosid`.

- **workflow_dispatch**: builds any ref with optional custom tag
- **pull_request**: validates Docker build on PRs without pushing images
- Push gate ensures PR builds don't push to GHCR

This unblocks manually triggering builds for existing PRs (e.g. #151).