### PR TITLE
support mdoc verification for full device response

### DIFF
--- a/src/hooks/useOIDFlowSignHandler.ts
+++ b/src/hooks/useOIDFlowSignHandler.ts
@@ -311,7 +311,6 @@ async function createVpTokenFromMdoc(
 		mdoc.documents[0].docType,
 		disclosedClaims ?? [],
 	);
-	console.log("presentation Defnition: ", presentationDefinition)
 	let deviceResponseMDoc: MDoc;
 	if (responseUri) {
 		const { deviceResponseMDoc: drm } = await keystore.generateDeviceResponse(

--- a/src/hooks/useOIDFlowSignHandler.ts
+++ b/src/hooks/useOIDFlowSignHandler.ts
@@ -303,7 +303,11 @@ async function createVpTokenFromMdoc(
 		throw new Error('disclosedClaims required for mdoc presentation');
 	}
 	const deviceResponse = cbor.decode(fromBase64Url(credentialRaw));
-	const issuerSigned = deviceResponse.documents[0].issuerSigned;
+	// `deviceResponse` may be a full DeviceResponse envelope, or a bare
+	// IssuerSigned structure directly (what real-world/interop issuers, e.g.
+	// geneva2026.mdoc.online, send for mso_mdoc credential responses) - in
+	// the latter case it already *is* the issuerSigned structure.
+	const issuerSigned = deviceResponse.documents?.[0]?.issuerSigned ?? deviceResponse;
 	const issuerSignedBytes = cbor.encode(issuerSigned);
 	const issuerSignedB64 = toBase64Url(issuerSignedBytes);
 	const mdoc = parseIssuerSignedToMDoc(issuerSignedB64);

--- a/src/hooks/useOIDFlowSignHandler.ts
+++ b/src/hooks/useOIDFlowSignHandler.ts
@@ -10,6 +10,9 @@ import { buildMdocPresentationDefinition, parseIssuerSignedToMDoc } from '@/lib/
 import { detectCredentialFormat, VerifiableCredentialFormat } from 'wallet-common';
 import { MDoc } from '@auth0/mdl';
 import { LocalStorageKeystore } from '@/services/LocalStorageKeystore';
+import * as cbor from 'cbor-x'; 
+import { fromBase64Url, toBase64Url } from "../util";
+
 
 interface ProofTypeConfig {
 	key_attestations_required?: Record<string, unknown> | null;
@@ -299,13 +302,16 @@ async function createVpTokenFromMdoc(
 	if (!disclosedClaims?.length) {
 		throw new Error('disclosedClaims required for mdoc presentation');
 	}
-
-	const mdoc = parseIssuerSignedToMDoc(credentialRaw);
-	const presentationDefinition = buildMdocPresentationDefinition(
+	const deviceResponse = cbor.decode(fromBase64Url(credentialRaw));
+	const issuerSigned = deviceResponse.documents[0].issuerSigned;
+	const issuerSignedBytes = cbor.encode(issuerSigned);
+	const issuerSignedB64 = toBase64Url(issuerSignedBytes);
+	const mdoc = parseIssuerSignedToMDoc(issuerSignedB64);
+	const presentationDefinition = buildMdocPresentationDefinition(	
 		mdoc.documents[0].docType,
 		disclosedClaims ?? [],
 	);
-
+	console.log("presentation Defnition: ", presentationDefinition)
 	let deviceResponseMDoc: MDoc;
 	if (responseUri) {
 		const { deviceResponseMDoc: drm } = await keystore.generateDeviceResponse(

--- a/src/lib/mdoc/mdoc.test.ts
+++ b/src/lib/mdoc/mdoc.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import * as cbor from "cbor-x";
+import { extractDocTypeFromIssuerAuth } from "./mdoc";
+
+/**
+ * `extractDocTypeFromIssuerAuth` reads docType from the MSO (MobileSecurityObject)
+ * embedded in a bare IssuerSigned structure's `issuerAuth` COSE_Sign1 payload -
+ * needed because IssuerSigned itself has no docType field. Per ISO 18013-5
+ * §9.1.2.4, the payload is a bstr whose content decodes to a tag-24-wrapped
+ * bstr, which itself decodes to the actual MSO map - two nested decode steps,
+ * confirmed against a real geneva2026.mdoc.online credential.
+ */
+function buildIssuerAuth(docType: string): unknown[] {
+	const msoBytes = cbor.encode({ docType });
+	const taggedMsoBytes = cbor.encode(new cbor.Tag(msoBytes, 24));
+	return [
+		new Uint8Array(0), // protected headers (opaque to the wallet)
+		{}, // unprotected headers
+		taggedMsoBytes, // payload
+		new Uint8Array(64), // signature (opaque to the wallet)
+	];
+}
+
+describe("extractDocTypeFromIssuerAuth", () => {
+	it("extracts docType from a tag-24-wrapped MSO payload", () => {
+		const issuerAuth = buildIssuerAuth("org.iso.18013.5.1.mDL");
+		expect(extractDocTypeFromIssuerAuth(issuerAuth)).toBe("org.iso.18013.5.1.mDL");
+	});
+
+	it("works for any docType, not just mDL", () => {
+		const issuerAuth = buildIssuerAuth("eu.europa.ec.eudi.pid.1");
+		expect(extractDocTypeFromIssuerAuth(issuerAuth)).toBe("eu.europa.ec.eudi.pid.1");
+	});
+
+	it("also accepts an MSO payload without the tag-24 wrapper", () => {
+		const msoBytes = cbor.encode({ docType: "org.iso.23220.photoid.1" });
+		const issuerAuth = [new Uint8Array(0), {}, msoBytes, new Uint8Array(64)];
+		expect(extractDocTypeFromIssuerAuth(issuerAuth)).toBe("org.iso.23220.photoid.1");
+	});
+
+	it("throws when issuerAuth has no payload", () => {
+		expect(() => extractDocTypeFromIssuerAuth([new Uint8Array(0), {}])).toThrow();
+	});
+
+	it("throws when the MSO is missing docType", () => {
+		const msoBytes = cbor.encode({ somethingElse: "value" });
+		const taggedMsoBytes = cbor.encode(new cbor.Tag(msoBytes, 24));
+		const issuerAuth = [new Uint8Array(0), {}, taggedMsoBytes, new Uint8Array(64)];
+		expect(() => extractDocTypeFromIssuerAuth(issuerAuth)).toThrow();
+	});
+});

--- a/src/lib/mdoc/mdoc.ts
+++ b/src/lib/mdoc/mdoc.ts
@@ -1,5 +1,5 @@
 import { base64url } from 'jose';
-import { cborDecode, cborEncode } from '@auth0/mdl/lib/cbor';
+import { cborDecode, cborEncode, DataItem } from '@auth0/mdl/lib/cbor';
 import { parse } from '@auth0/mdl';
 
 /**
@@ -21,6 +21,32 @@ export function parseIssuerSignedToMDoc(raw: string) {
 		status: 0,
 	};
 	return parse(cborEncode(envelope));
+}
+
+/**
+ * Extract `docType` from the MSO (MobileSecurityObject) embedded in a bare
+ * `IssuerSigned` structure's `issuerAuth` COSE_Sign1 payload (index 2 of the
+ * 4-element array) - the only place docType is available when there's no
+ * enclosing `{docType, issuerSigned}` document wrapper (e.g. a stored mdoc
+ * credential issued directly as a bare IssuerSigned, as real-world/interop
+ * issuers such as geneva2026.mdoc.online do for `mso_mdoc` credential
+ * responses).
+ *
+ * @param issuerAuth - The decoded COSE_Sign1 array `[protected, unprotected, payload, signature]`
+ * @returns The MSO's `docType`
+ */
+export function extractDocTypeFromIssuerAuth(issuerAuth: unknown[]): string {
+	const payload = issuerAuth?.[2] as Uint8Array | undefined;
+	if (!payload) {
+		throw new Error('issuerAuth is not a COSE_Sign1 array (missing payload)');
+	}
+	const decoded = cborDecode(payload);
+	const mso = decoded instanceof DataItem ? decoded.data : decoded;
+	const docType = mso?.get?.('docType');
+	if (!docType) {
+		throw new Error('MSO missing docType');
+	}
+	return docType;
 }
 
 /**

--- a/src/services/CredentialMatchingService.test.ts
+++ b/src/services/CredentialMatchingService.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import * as cbor from "cbor-x";
+import { shapeCredential } from "./CredentialMatchingService";
+import { ExtendedVcEntity } from "@/context/CredentialsContext";
+import { toBase64Url } from "../util";
+
+/**
+ * `shapeCredential` (mso_mdoc branch) must handle both stored-credential
+ * shapes seen in practice:
+ * - a full DeviceResponse-shaped envelope (`{documents: [{docType,
+ *   issuerSigned}], ...}`) - our own vc-issuer's convention.
+ * - a bare IssuerSigned structure (`{nameSpaces, issuerAuth}`) directly, with
+ *   docType read from the MSO embedded in issuerAuth instead of a docType
+ *   field (IssuerSigned has none) - what real-world/interop issuers (e.g.
+ *   geneva2026.mdoc.online) send for mso_mdoc credential responses.
+ */
+
+function buildIssuerAuth(docType: string): unknown[] {
+	const msoBytes = cbor.encode({ docType });
+	const taggedMsoBytes = cbor.encode(new cbor.Tag(msoBytes, 24));
+	return [new Uint8Array(0), {}, taggedMsoBytes, new Uint8Array(64)];
+}
+
+function buildItem(elementIdentifier: string, elementValue: string) {
+	const itemBytes = cbor.encode({
+		digestID: 0,
+		random: new Uint8Array(16),
+		elementIdentifier,
+		elementValue,
+	});
+	return new cbor.Tag(itemBytes, 24);
+}
+
+function buildNameSpaces(namespace: string) {
+	return {
+		[namespace]: [buildItem("given_name", "Jane"), buildItem("family_name", "Doe")],
+	};
+}
+
+function mockMdocCredential(bytes: Uint8Array): ExtendedVcEntity {
+	return {
+		format: "mso_mdoc",
+		data: toBase64Url(bytes),
+		batchId: 1,
+	} as unknown as ExtendedVcEntity;
+}
+
+describe("shapeCredential (mso_mdoc)", () => {
+	it("shapes a full DeviceResponse-shaped envelope", () => {
+		const docType = "org.iso.18013.5.1.mDL";
+		const namespace = "org.iso.18013.5.1";
+		const envelope = {
+			documents: [{
+				docType,
+				issuerSigned: { nameSpaces: buildNameSpaces(namespace), issuerAuth: buildIssuerAuth(docType) },
+			}],
+			status: 0,
+		};
+
+		const shaped = shapeCredential(mockMdocCredential(cbor.encode(envelope)));
+
+		expect(shaped).not.toBeNull();
+		expect((shaped as any).doctype).toBe(docType);
+		expect((shaped as any).namespaces[namespace].given_name).toBe("Jane");
+	});
+
+	it("shapes a bare IssuerSigned structure, deriving docType from the MSO", () => {
+		const docType = "eu.europa.ec.eudi.pid.1";
+		const namespace = "eu.europa.ec.eudi.pid.1";
+		const bareIssuerSigned = {
+			nameSpaces: buildNameSpaces(namespace),
+			issuerAuth: buildIssuerAuth(docType),
+		};
+
+		const shaped = shapeCredential(mockMdocCredential(cbor.encode(bareIssuerSigned)));
+
+		expect(shaped).not.toBeNull();
+		expect((shaped as any).doctype).toBe(docType);
+		expect((shaped as any).namespaces[namespace].family_name).toBe("Doe");
+	});
+
+	it("returns null (not throws) for an unparseable mdoc", () => {
+		const garbage = cbor.encode({ somethingElse: "value" });
+		expect(shapeCredential(mockMdocCredential(garbage))).toBeNull();
+	});
+});

--- a/src/services/CredentialMatchingService.ts
+++ b/src/services/CredentialMatchingService.ts
@@ -13,7 +13,8 @@
 import { ExtendedVcEntity } from '@/context/CredentialsContext';
 import { DcqlQuery, DcqlCredential, DcqlQueryResult } from 'dcql';
 import { logger } from '@/logger';
-import { parseIssuerSignedToMDoc } from '@/lib/mdoc/mdoc';
+import * as cbor from 'cbor-x'; 
+import { fromBase64Url } from "../util";
 
 export interface CredentialMatch {
 	input_descriptor_id: string;
@@ -94,7 +95,6 @@ export function matchCredentials(
 	return { matches };
 }
 
-
 /**
  * Shape an ExtendedVcEntity into a DcqlCredential for the dcql library.
  * Returns null if shaping fails (e.g., unparseable mDOC).
@@ -104,17 +104,27 @@ function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _bat
 
 	if (format === 'mso_mdoc') {
 		try {
-			const mdoc = parseIssuerSignedToMDoc(credential.data);
-			const [document] = mdoc.documents;
+			const data = credential.data;
+			const bytes = fromBase64Url(data);
+			const mdoc = cbor.decode(bytes); // full DeviceResponse (or IssuerSigned, depending on stored shape)
 
-			const namespaces: Record<string, any> = {};
-			for (const nsName of document.issuerSignedNameSpaces) {
-				namespaces[nsName] = document.getIssuerNameSpace(nsName);
+			const doc = mdoc.documents[0];
+			const docType = doc.docType; 
+			const rawNameSpaces = doc.issuerSigned.nameSpaces; // { [namespaceName]: TaggedItem[] }
+
+			const namespaces: Record<string, Record<string, unknown>> = {};
+
+			for (const [nsName, items] of Object.entries(rawNameSpaces as Record<string, any[]>)) {
+				const claims: Record<string, unknown> = {};
+				for (const taggedItem of items) {
+					const item = cbor.decode(taggedItem.value);
+					claims[item.elementIdentifier] = item.elementValue;
+				}
+				namespaces[nsName] = claims;
 			}
-
 			return {
 				credential_format: 'mso_mdoc',
-				doctype: document.docType,
+				doctype: docType,
 				namespaces,
 				cryptographic_holder_binding: true,
 				_batchId: credential.batchId,
@@ -124,6 +134,7 @@ function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _bat
 			return null;
 		}
 	}
+
 
 	// SD-JWT (vc+sd-jwt or dc+sd-jwt)
 	const signedClaims = credential.parsedCredential?.signedClaims;

--- a/src/services/CredentialMatchingService.ts
+++ b/src/services/CredentialMatchingService.ts
@@ -13,8 +13,9 @@
 import { ExtendedVcEntity } from '@/context/CredentialsContext';
 import { DcqlQuery, DcqlCredential, DcqlQueryResult } from 'dcql';
 import { logger } from '@/logger';
-import * as cbor from 'cbor-x'; 
+import * as cbor from 'cbor-x';
 import { fromBase64Url } from "../util";
+import { extractDocTypeFromIssuerAuth } from '@/lib/mdoc/mdoc';
 
 export interface CredentialMatch {
 	input_descriptor_id: string;
@@ -98,19 +99,36 @@ export function matchCredentials(
 /**
  * Shape an ExtendedVcEntity into a DcqlCredential for the dcql library.
  * Returns null if shaping fails (e.g., unparseable mDOC).
+ *
+ * Exported for direct unit testing of the mso_mdoc envelope-shape handling,
+ * without needing to build a full DcqlQuery to exercise it via matchCredentials.
  */
-function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _batchId?: number }) | null {
+export function shapeCredential(credential: ExtendedVcEntity): (DcqlCredential & { _batchId?: number }) | null {
 	const format = credential.format || 'vc+sd-jwt';
 
 	if (format === 'mso_mdoc') {
 		try {
 			const data = credential.data;
 			const bytes = fromBase64Url(data);
-			const mdoc = cbor.decode(bytes); // full DeviceResponse (or IssuerSigned, depending on stored shape)
+			const mdoc = cbor.decode(bytes); // full DeviceResponse, or a bare IssuerSigned structure
 
-			const doc = mdoc.documents[0];
-			const docType = doc.docType; 
-			const rawNameSpaces = doc.issuerSigned.nameSpaces; // { [namespaceName]: TaggedItem[] }
+			let docType: string;
+			let rawNameSpaces: Record<string, any[]>;
+			if (mdoc.documents?.[0]) {
+				const doc = mdoc.documents[0];
+				docType = doc.docType;
+				rawNameSpaces = doc.issuerSigned.nameSpaces; // { [namespaceName]: TaggedItem[] }
+			} else if (mdoc.nameSpaces && mdoc.issuerAuth) {
+				// Bare IssuerSigned structure (no documents[] envelope) - what
+				// real-world/interop issuers (e.g. geneva2026.mdoc.online) send for
+				// mso_mdoc credential responses. IssuerSigned has no docType field of
+				// its own; it has to be read from the MSO embedded in issuerAuth's
+				// COSE_Sign1 payload instead.
+				docType = extractDocTypeFromIssuerAuth(mdoc.issuerAuth);
+				rawNameSpaces = mdoc.nameSpaces;
+			} else {
+				throw new Error('mdoc credential envelope missing documents[] (and not a bare IssuerSigned structure either)');
+			}
 
 			const namespaces: Record<string, Record<string, unknown>> = {};
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,12 +5,12 @@ export function coerce<T>(value: T): T {
 }
 
 
-export function toU8(b: BufferSource) {
-	if (b instanceof ArrayBuffer) {
-		return new Uint8Array(b);
-	} else {
-		return new Uint8Array(b.buffer);
-	}
+export function toU8(b: BufferSource): Uint8Array {
+  if (b instanceof ArrayBuffer) {
+    return new Uint8Array(b);
+  } else {
+    return new Uint8Array(b.buffer, b.byteOffset, b.byteLength);
+  }
 }
 
 export function toBase64(binary: BufferSource): string {


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? -->
This PR makes the wallet-frontend to handle full device response mdoc in the credential matching and when creating VP token for mdoc.

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix
- [ x] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Related issues / tickets
<!-- Link issues with keywords to auto-close, e.g. "Fixes #123" -->
Fixes #190 

## Changes
<!-- Bullet list of the key changes -->
- Credential matching can parse full device response with the dcql
- VP token generator can handle the full device response for mdoc. 
## Architecture decisions
<!-- Anything related to the design choices made to perform the changes -->
- ...

## Screenshots / recordings (if UI changes)
<!-- Before/after images or a short recording -->
<img width="1842" height="980" alt="image" src="https://github.com/user-attachments/assets/435ecfb1-5dff-4304-9fff-cc3e33f9956b" />

- ...

## How to test
<!-- Provide step-by-step instructions -->
- Deploy the wallet frontend.
- Deploy the issuer, API gateway, and verifier using the latest VC version.
- Obtain an mdoc credential.
- Request verification from the verifier.

## Checklist
- [ x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not) 
- [ ] I updated documentation (if needed)
- [ x] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

## Notes for reviewers
<!-- Risk areas, review order, follow-ups, rollout plan -->
