### PR TITLE
fix: preserve dc_api.jwt response envelope and correlate via state

### DIFF
--- a/src/lib/openid-flow/platforms/dc-api/DCAPIRequest.test.ts
+++ b/src/lib/openid-flow/platforms/dc-api/DCAPIRequest.test.ts
@@ -75,6 +75,27 @@ describe('DCAPIRequest', () => {
 
 			expect(request.responseMode).toBe('dc_api.jwt');
 		});
+
+		it('parses state when present', () => {
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('nonce', 'test-nonce');
+			url.searchParams.set('dcql_query', JSON.stringify(validDcqlQuery));
+			url.searchParams.set('state', 'verifier-state-abc');
+
+			const request = new DCAPIRequest(url);
+
+			expect(request.state).toBe('verifier-state-abc');
+		});
+
+		it('leaves state undefined when absent', () => {
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('nonce', 'test-nonce');
+			url.searchParams.set('dcql_query', JSON.stringify(validDcqlQuery));
+
+			const request = new DCAPIRequest(url);
+
+			expect(request.state).toBeUndefined();
+		});
 	});
 
 	describe('signed request parsing', () => {
@@ -219,6 +240,24 @@ describe('DCAPIRequest', () => {
 			const request = new DCAPIRequest(url);
 
 			expect(request.clientMetadata).toEqual(clientMetadata);
+		});
+
+		it('parses state from JWT payload', async () => {
+			const { jwt } = await createSignedJwt({
+				nonce: 'test-nonce',
+				dcql_query: validDcqlQuery,
+				client_id: 'https://verifier.example.com',
+				expected_origins: ['https://verifier.example.com'],
+				state: 'verifier-state-abc',
+			});
+
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('request', jwt);
+			url.searchParams.set('client_id', 'https://verifier.example.com');
+
+			const request = new DCAPIRequest(url);
+
+			expect(request.state).toBe('verifier-state-abc');
 		});
 
 		it('logs warning when iss claim is present', async () => {

--- a/src/lib/openid-flow/platforms/dc-api/DCAPIRequest.ts
+++ b/src/lib/openid-flow/platforms/dc-api/DCAPIRequest.ts
@@ -46,6 +46,10 @@ export class DCAPIRequest {
 		return this.data.responseMode;
 	}
 
+	get state() {
+		return this.data.state;
+	}
+
 	get clientId() {
 		return this.isSigned
 			? (this.data as SignedDCAPIRequest).clientId
@@ -120,6 +124,7 @@ export class DCAPIRequest {
 			nonce: payload.nonce,
 			dcqlQuery: payload.dcql_query,
 			responseMode: payload.response_mode,
+			state: payload.state,
 			clientId: payload.client_id,
 			keyMaterial: keyMaterial,
 			rawJwt: jwt,
@@ -156,6 +161,7 @@ export class DCAPIRequest {
 			nonce: url.searchParams.get('nonce'),
 			dcqlQuery: dcqlQueryParam,
 			responseMode: url.searchParams.get('response_mode') ?? undefined,
+			state: url.searchParams.get('state') ?? undefined,
 		});
 
 		if (!success) {

--- a/src/lib/openid-flow/platforms/dc-api/DCAPISession.test.ts
+++ b/src/lib/openid-flow/platforms/dc-api/DCAPISession.test.ts
@@ -249,6 +249,45 @@ describe('DCAPISession', () => {
 			});
 		});
 
+		it('echoes state in dc_api mode response when the request supplied one', async () => {
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('request_id', 'test-request-123');
+			url.searchParams.set('nonce', 'test-nonce');
+			url.searchParams.set('dcql_query', JSON.stringify(validDcqlQuery));
+			url.searchParams.set('response_mode', 'dc_api');
+			url.searchParams.set('state', 'verifier-state-abc');
+
+			const session = new DCAPISession(url);
+			await session.initialize();
+
+			const vpToken = { credential: ['token'] };
+			await session.sendResponse(vpToken);
+
+			expect(mockMode.send).toHaveBeenCalledWith({
+				requestId: 'test-request-123',
+				payload: { vp_token: vpToken, state: 'verifier-state-abc' },
+			});
+		});
+
+		it('omits state from dc_api mode response when the request had none', async () => {
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('request_id', 'test-request-123');
+			url.searchParams.set('nonce', 'test-nonce');
+			url.searchParams.set('dcql_query', JSON.stringify(validDcqlQuery));
+			url.searchParams.set('response_mode', 'dc_api');
+
+			const session = new DCAPISession(url);
+			await session.initialize();
+
+			const vpToken = { credential: ['token'] };
+			await session.sendResponse(vpToken);
+
+			expect(mockMode.send).toHaveBeenCalledWith({
+				requestId: 'test-request-123',
+				payload: { vp_token: vpToken },
+			});
+		});
+
 		it('calls mode.close() after sending', async () => {
 			const url = new URL('https://wallet.example.com/dc');
 			url.searchParams.set('request_id', 'test-request-123');
@@ -298,6 +337,46 @@ describe('DCAPISession', () => {
 			// Verify decryption yields original payload
 			const { plaintext } = await compactDecrypt(jwe, privateKey);
 			const decrypted = JSON.parse(new TextDecoder().decode(plaintext));
+			expect(decrypted.vp_token).toEqual(vpToken);
+		});
+
+		it('encrypts state alongside vp_token for dc_api.jwt mode when the request supplied one', async () => {
+			const { publicKey, privateKey } = await generateKeyPair('ECDH-ES');
+			const encJwk = await exportJWK(publicKey);
+			encJwk.use = 'enc';
+			encJwk.kid = 'enc-key-1';
+
+			const { jwt } = await createSignedJwt({
+				nonce: 'test-nonce',
+				dcql_query: validDcqlQuery,
+				client_id: 'https://verifier.example.com',
+				expected_origins: ['https://verifier.example.com'],
+				response_mode: 'dc_api.jwt',
+				state: 'verifier-state-abc',
+				client_metadata: { jwks: { keys: [encJwk] } },
+			});
+
+			const url = new URL('https://wallet.example.com/dc');
+			url.searchParams.set('request_id', 'test-request-123');
+			url.searchParams.set('request', jwt);
+			url.searchParams.set('client_id', 'https://verifier.example.com');
+
+			const session = new DCAPISession(url);
+			await session.initialize();
+
+			const vpToken = { credential: ['token1'] };
+			await session.sendResponse(vpToken);
+
+			const sendCall = mockMode.send.mock.calls[0][0];
+			const jwe = sendCall.payload.response;
+
+			// The verifier's only correlator for this response - it must be
+			// inside the encrypted payload alongside vp_token, not left in the
+			// clear, since the whole point of dc_api.jwt is that the response
+			// body is opaque to anyone but the verifier.
+			const { plaintext } = await compactDecrypt(jwe, privateKey);
+			const decrypted = JSON.parse(new TextDecoder().decode(plaintext));
+			expect(decrypted.state).toBe('verifier-state-abc');
 			expect(decrypted.vp_token).toEqual(vpToken);
 		});
 

--- a/src/lib/openid-flow/platforms/dc-api/DCAPISession.ts
+++ b/src/lib/openid-flow/platforms/dc-api/DCAPISession.ts
@@ -60,9 +60,17 @@ export class DCAPISession {
 	}
 
 	public async sendResponse(vpToken: Record<string, string[]>): Promise<void> {
-		const payload = this.request.responseMode === 'dc_api.jwt'
-			? { response: await this.#encryptResponse(vpToken) }
+		// state (when the request supplied one) must be echoed back verbatim -
+		// it's the verifier's only means of correlating this response to the
+		// right authorization session, since it arrives via the DC API
+		// callback rather than an HTTP POST to a known endpoint.
+		const responseBody: Record<string, unknown> = this.request.state
+			? { vp_token: vpToken, state: this.request.state }
 			: { vp_token: vpToken };
+
+		const payload = this.request.responseMode === 'dc_api.jwt'
+			? { response: await this.#encryptResponse(responseBody) }
+			: responseBody;
 
 		this.mode.send({ requestId: this.requestId, payload });
 		this.close();
@@ -85,7 +93,7 @@ export class DCAPISession {
 		throw new Error('Unable to detect DC API mode, no supported environment detected');
 	}
 
-	async #encryptResponse(vpToken: Record<string, string[]>): Promise<string> {
+	async #encryptResponse(responseBody: Record<string, unknown>): Promise<string> {
 		if (!this.request.clientMetadata?.jwks?.keys?.length) {
 			throw new Error('dc_api.jwt response_mode requires client_metadata.jwks');
 		}
@@ -105,7 +113,7 @@ export class DCAPISession {
 
 		const publicKey = await importJWK(encKey as JWK, alg);
 
-		const jwe = await new EncryptJWT({ vp_token: vpToken })
+		const jwe = await new EncryptJWT(responseBody)
 			.setProtectedHeader({
 				alg,
 				enc,

--- a/src/lib/openid-flow/platforms/dc-api/modes.test.ts
+++ b/src/lib/openid-flow/platforms/dc-api/modes.test.ts
@@ -243,7 +243,7 @@ describe('DCAPIWalletCompanionMode', () => {
 			);
 		});
 
-		it('posts WC_WALLET_RESPONSE with encrypted response', () => {
+		it('posts WC_WALLET_RESPONSE with encrypted response wrapped in a response envelope', () => {
 			const encryptedResponse = 'eyJhbGciOiJFQ0RILUVT...encrypted...';
 
 			mode.send({
@@ -251,11 +251,34 @@ describe('DCAPIWalletCompanionMode', () => {
 				payload: { response: encryptedResponse },
 			});
 
+			// Must stay wrapped as { response: jwe } - a bare JWE string here
+			// (the old, buggy behavior) leaves the eventual DigitalCredential.data
+			// with no .response property for a verifier/consumer to find the
+			// JWE under, matching neither the native mobile SDKs nor the
+			// OpenID4VP DC API profile's dc_api.jwt shape.
 			expect(mockOpener.postMessage).toHaveBeenCalledWith(
 				{
 					type: 'WC_WALLET_RESPONSE',
 					requestId: 'test-request-123',
-					response: encryptedResponse,
+					response: { response: encryptedResponse },
+				},
+				'https://verifier.example.com'
+			);
+		});
+
+		it('forwards state alongside vp_token in the response envelope', () => {
+			const vpToken = { credential: ['token1'] };
+
+			mode.send({
+				requestId: 'test-request-123',
+				payload: { vp_token: vpToken, state: 'verifier-state-abc' },
+			});
+
+			expect(mockOpener.postMessage).toHaveBeenCalledWith(
+				{
+					type: 'WC_WALLET_RESPONSE',
+					requestId: 'test-request-123',
+					response: { vp_token: vpToken, state: 'verifier-state-abc' },
 				},
 				'https://verifier.example.com'
 			);

--- a/src/lib/openid-flow/platforms/dc-api/modes.ts
+++ b/src/lib/openid-flow/platforms/dc-api/modes.ts
@@ -57,9 +57,19 @@ export class DCAPIWalletCompanionMode implements DCAPIMode {
 		if (payload.error) {
 			message.error = payload.error;
 		} else if (payload.response) {
-			message.response = payload.response;
+			// dc_api.jwt: payload.response is the bare JWE compact-serialization
+			// string produced by DCAPISession#encryptResponse. It must stay
+			// wrapped in a { response } envelope here - the OpenID4VP DC API
+			// profile and the native mobile SDKs both put the JWE at
+			// data.response, not at data directly. Assigning it unwrapped
+			// (as this used to) meant the final DigitalCredential.data was a
+			// bare JWE string with no .response property to find it under.
+			message.response = { response: payload.response };
 		} else if (payload.vp_token) {
-			message.response = { vp_token: payload.vp_token };
+			// Forward the whole payload (vp_token, and state when the request
+			// supplied one) rather than reconstructing a subset - a verifier
+			// correlating this response via state would otherwise never see it.
+			message.response = payload;
 		}
 
 		window.opener.postMessage(message, this.#verifiedOrigin);

--- a/src/lib/openid-flow/platforms/dc-api/resources.ts
+++ b/src/lib/openid-flow/platforms/dc-api/resources.ts
@@ -48,6 +48,12 @@ const BaseDCApiRequestSchema = z.object({
 	nonce: z.string({ required_error: 'Missing required nonce parameter' }).min(1, 'nonce cannot be empty'),
 	dcqlQuery: dcqlQuerySchema,
 	responseMode: DCApiResponseModeSchema,
+	// The verifier's only means of correlating this response back to the
+	// right authorization session - the response arrives via the DC API
+	// callback, a wholly separate channel from the original request, with no
+	// other correlator available. Optional per OpenID4VP, but must be echoed
+	// back verbatim in the response whenever the request supplies it.
+	state: z.string().optional(),
 }).strict();
 
 export type SignedDCAPIRequest = z.infer<typeof SignedDCApiRequestSchema>;


### PR DESCRIPTION
## Summary

Two real bugs found in the popup-based DC API flow (`DCAPIRequest`/`DCAPISession`/`DCAPIWalletCompanionMode`) while cross-checking it against the native Kotlin/Swift wallet SDKs' DC API implementations (which had the same two gaps, since fixed):

- Fixes #193: `dc_api.jwt` responses were delivered as a bare JWE string instead of `{ response: "<jwe>" }` - `DCAPIWalletCompanionMode#send` unwrapped the envelope that `DCAPISession#sendResponse` had correctly built.
- Fixes #194: `state` was never captured from an incoming request or echoed back in the response - the verifier's only correlator for a response arriving via `postMessage` rather than an HTTP POST. `wallet-companion`'s request-building side already forwards `state` into the popup URL; it was silently dropped on ingestion here.

## Changes

- `resources.ts`: add optional `state` to `BaseDCApiRequestSchema`.
- `DCAPIRequest.ts`: parse `state` from both the plain-params and signed-JWT paths; add a `state` getter.
- `DCAPISession.ts`: `sendResponse` now builds `{ vp_token, state? }` and threads that through `#encryptResponse` for `dc_api.jwt` mode (state ends up inside the encrypted payload, alongside `vp_token`, not left in the clear).
- `modes.ts`: `payload.response` (the JWE) is now re-wrapped as `{ response: ... }` before posting, matching the `payload.vp_token` branch's existing re-wrap pattern; that branch now forwards the whole payload object (so `state` rides along) instead of reconstructing a `{ vp_token }`-only subset.

## Test plan

- [x] `npx vitest run src/lib/openid-flow/platforms/dc-api/` - 69/69 passing, including new coverage for state capture/echo (both response modes) and the corrected envelope shape.
- [x] `npx eslint src/lib/openid-flow/platforms/dc-api/` - clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>