### PR TITLE
feat(auth): scope the anonymous token to wallet-registry

### DIFF
--- a/src/lib/auth/tokens/AuthTokens.test.ts
+++ b/src/lib/auth/tokens/AuthTokens.test.ts
@@ -87,16 +87,16 @@ describe('AuthTokens', () => {
 			expect(token.aud).toBe('wallet-backend');
 		});
 
-		it('requests an anonymous token with anonymous=true and tac=rl', async () => {
+		it('requests an anonymous token for wallet-registry with anonymous=true and tac=rl', async () => {
 			client.requestAccessToken.mockResolvedValue(
-				tokenResponse(makeJwt({ tac: 'rl' })),
+				tokenResponse(makeJwt({ aud: 'wallet-registry', tac: 'rl' })),
 			);
 			const auth = makeAuthTokens();
 
 			await auth.ensureAnonymousToken();
 
 			expect(client.requestAccessToken).toHaveBeenCalledWith(
-				'wallet-backend',
+				'wallet-registry',
 				'default',
 				'rl',
 				true,

--- a/src/lib/auth/tokens/AuthTokens.ts
+++ b/src/lib/auth/tokens/AuthTokens.ts
@@ -48,7 +48,13 @@ export class AuthTokens {
 			tac: 'rwlid',
 		},
 		'anonymous': {
-			audience: 'wallet-backend',
+			// wallet-registry (not wallet-backend): this token intentionally
+			// omits identity (sub), so it's scoped to a narrower, specific
+			// audience rather than sharing the general-purpose backend
+			// audience with the fully-authenticated 'backend' token above.
+			// The backend still accepts wallet-backend for this token
+			// transitionally, but wallet-registry is the intended value.
+			audience: 'wallet-registry',
 			tac: 'rl',
 			anonymous: true,
 		},


### PR DESCRIPTION
## Summary
The `'anonymous'` auth-token manifest entry (used for trust-evaluation calls and engine-transport auth that deliberately omit the caller's identity - see `AuthTokens.MANIFEST`) requested the same `wallet-backend` audience as the fully-authenticated `'backend'` token. That meant an identity-free token was valid anywhere a normal authenticated token would be, rather than being scoped to the specific purposes it's actually used for.

Changes the requested audience to `wallet-registry` - the intended long-term audience for this token.

## Backend coordination
go-wallet-backend's SPOCP policy (`rules/default.rules`) has already been updated to accept `wallet-registry` alongside `wallet-backend` (transitionally, for already-deployed clients) - see [go-wallet-backend#258](https://github.com/sirosfoundation/go-wallet-backend/pull/258). That backend change is not order-dependent with this one: either can land first, since the backend accepts both values during the migration window.

Separately (and more fundamentally), go-wallet-backend's anonymous-token issuance now requires a real, already-authenticated session (it previously had no such requirement at all) - this frontend change doesn't depend on that fix, since every current caller of `ensureAnonymousToken()` already has a valid session by the time it's invoked (verified: the AuthZEN/engine-transport call sites are only reachable from `CredentialsContextProvider`'s post-login-gated effects, or from `/cb/*`, which is behind `<PrivateRoute>`).

## Test plan
- [x] `AuthTokens.test.ts` updated and passing (asserts the anonymous request now uses `wallet-registry`)
- [x] `vitest run` on the auth token/client test files - 30/30 pass
- [x] `tsc --noEmit` - no new type errors introduced (pre-existing unrelated errors in `mdocProtocol`/`ScanPhysicalID`/`worker.ts` are untouched by this change)
- [x] `eslint` on changed files - clean