### PR TITLE
fix: send X-Tenant-ID header to `/auth/token` endpoint in auth server client

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -154,7 +154,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 
 	// Define clearSession early so it can be used by token refresh config
 	const clearSession = useCallback((): void => {
-		authServer.logout().catch((e) => logger.error('Failed to clear server session', e));
+		authServer.logout(tenantId ?? 'default').catch((e) => logger.error('Failed to clear server session', e));
 		clearSessionStorage();
 		authTokens.clear();
 		removePrivateDataEtag();
@@ -162,7 +162,7 @@ export function useApi(isOnlineProp: boolean = true): BackendApi {
 		clearOIDCState('registration'); // Clear OIDC gate tokens on logout
 		clearOIDCState('login');
 		events.dispatchEvent(new CustomEvent<ClearSessionEvent>(CLEAR_SESSION_EVENT));
-	}, [authServer, authTokens, clearSessionStorage, removePrivateDataEtag]);
+	}, [authServer, authTokens, clearSessionStorage, removePrivateDataEtag, tenantId]);
 
 	// Stable ref for clearSession to avoid stale closures in token refresh
 	const clearSessionRef = useRef<() => void>(clearSession);

--- a/src/lib/auth/auth-server/AuthServerClient.test.ts
+++ b/src/lib/auth/auth-server/AuthServerClient.test.ts
@@ -4,13 +4,11 @@ import { AuthServerClient } from './AuthServerClient';
 
 vi.mock('axios', () => ({
 	default: {
-		post: vi.fn(),
-		delete: vi.fn(),
+		request: vi.fn(),
 	},
 }));
 
-const post = vi.mocked(axios.post);
-const del = vi.mocked(axios.delete);
+const request = vi.mocked(axios.request);
 
 const BASE_URL = 'https://backend.example.com';
 
@@ -71,14 +69,13 @@ describe('AuthServerClient', () => {
 	let client: AuthServerClient;
 
 	beforeEach(() => {
-		post.mockReset();
-		del.mockReset();
+		request.mockReset();
 		client = new AuthServerClient({ baseUrl: BASE_URL });
 	});
 
 	describe('requestAccessToken', () => {
 		it('posts the token request with the expected body and header', async () => {
-			post.mockResolvedValue(okData(tokenData));
+			request.mockResolvedValue(okData(tokenData));
 
 			const res = await client.requestAccessToken(
 				'wallet-backend',
@@ -87,53 +84,57 @@ describe('AuthServerClient', () => {
 				true,
 			);
 
-			expect(post).toHaveBeenCalledTimes(1);
-			const [url, body, cfg] = post.mock.calls[0];
-			expect(url).toBe(`${BASE_URL}/auth/token`);
-			expect(body).toEqual({
+			expect(request).toHaveBeenCalledTimes(1);
+			const [cfg] = request.mock.calls[0];
+			expect(cfg?.method).toBe('POST');
+			expect(cfg?.url).toBe(`${BASE_URL}/auth/token`);
+			expect(cfg?.data).toEqual({
 				aud: 'wallet-backend',
 				tac: 'rl',
 				tenant_id: 'default',
 				anonymous: true,
 			});
-			expect(cfg?.headers).toMatchObject({ 'X-Token-Mode': 'session' });
+			expect(cfg?.headers).toMatchObject({
+				'X-Token-Mode': 'session',
+				'X-Tenant-ID': 'default',
+			});
 			expect(res).toEqual(tokenData);
 		});
 
 		it('dedupes concurrent identical requests', async () => {
-			post.mockResolvedValue(okData(tokenData));
+			request.mockResolvedValue(okData(tokenData));
 
 			const [a, b] = await Promise.all([
 				client.requestAccessToken('wallet-backend', 'default', 'rl', true),
 				client.requestAccessToken('wallet-backend', 'default', 'rl', true),
 			]);
 
-			expect(post).toHaveBeenCalledTimes(1);
+			expect(request).toHaveBeenCalledTimes(1);
 			expect(a).toEqual(b);
 		});
 
 		it('does not dedupe requests with different params', async () => {
-			post.mockResolvedValue(okData(tokenData));
+			request.mockResolvedValue(okData(tokenData));
 
 			await Promise.all([
 				client.requestAccessToken('wallet-backend', 'default', 'rl', true),
 				client.requestAccessToken('wallet-backend', 'default', 'rwlid'),
 			]);
 
-			expect(post).toHaveBeenCalledTimes(2);
+			expect(request).toHaveBeenCalledTimes(2);
 		});
 
 		it('issues a fresh request once the previous one settles', async () => {
-			post.mockResolvedValue(okData(tokenData));
+			request.mockResolvedValue(okData(tokenData));
 
 			await client.requestAccessToken('wallet-backend', 'default', 'rl', true);
 			await client.requestAccessToken('wallet-backend', 'default', 'rl', true);
 
-			expect(post).toHaveBeenCalledTimes(2);
+			expect(request).toHaveBeenCalledTimes(2);
 		});
 
 		it('throws on an invalid token response', async () => {
-			post.mockResolvedValue(okData({ nope: true }));
+			request.mockResolvedValue(okData({ nope: true }));
 
 			await expect(
 				client.requestAccessToken('wallet-backend', 'default'),
@@ -143,13 +144,13 @@ describe('AuthServerClient', () => {
 
 	describe('loginBegin', () => {
 		it('sends session mode + tenant headers and returns parsed data', async () => {
-			post.mockResolvedValue(okData(loginBeginData));
+			request.mockResolvedValue(okData(loginBeginData));
 
 			const res = await client.loginBegin('acme');
 
-			const [url, body, cfg] = post.mock.calls[0];
-			expect(url).toBe(`${BASE_URL}/auth/passkey/login/begin`);
-			expect(body).toEqual({});
+			const [cfg] = request.mock.calls[0];
+			expect(cfg?.url).toBe(`${BASE_URL}/auth/passkey/login/begin`);
+			expect(cfg?.data).toEqual({});
 			expect(cfg?.headers).toMatchObject({
 				'X-Token-Mode': 'session',
 				'X-Tenant-ID': 'acme',
@@ -159,18 +160,18 @@ describe('AuthServerClient', () => {
 		});
 
 		it('attaches the OIDC id token as a bearer when provided', async () => {
-			post.mockResolvedValue(okData(loginBeginData));
+			request.mockResolvedValue(okData(loginBeginData));
 
 			await client.loginBegin('acme', 'oidc-id-token');
 
-			const [, , cfg] = post.mock.calls[0];
+			const [cfg] = request.mock.calls[0];
 			expect(cfg?.headers).toMatchObject({
 				Authorization: 'Bearer oidc-id-token',
 			});
 		});
 
 		it('throws on an invalid response', async () => {
-			post.mockResolvedValue(okData({ challengeId: 123 }));
+			request.mockResolvedValue(okData({ challengeId: 123 }));
 
 			await expect(client.loginBegin('acme')).rejects.toThrow(
 				'Invalid login begin response',
@@ -180,7 +181,7 @@ describe('AuthServerClient', () => {
 
 	describe('loginFinish', () => {
 		it('posts the challenge and credential and returns parsed data', async () => {
-			post.mockResolvedValue(okData(loginFinishData));
+			request.mockResolvedValue(okData(loginFinishData));
 
 			const res = await client.loginFinish(
 				'chal-1',
@@ -188,29 +189,29 @@ describe('AuthServerClient', () => {
 				'default',
 			);
 
-			const [url, body] = post.mock.calls[0];
-			expect(url).toBe(`${BASE_URL}/auth/passkey/login/finish`);
-			expect(body).toMatchObject({ challengeId: 'chal-1' });
+			const [cfg] = request.mock.calls[0];
+			expect(cfg?.url).toBe(`${BASE_URL}/auth/passkey/login/finish`);
+			expect(cfg?.data).toMatchObject({ challengeId: 'chal-1' });
 			expect(res).toEqual(loginFinishData);
 		});
 	});
 
 	describe('registerBegin', () => {
 		it('posts tenantId + inviteCode in the body', async () => {
-			post.mockResolvedValue(okData(registerBeginData));
+			request.mockResolvedValue(okData(registerBeginData));
 
 			await client.registerBegin('acme', 'invite-123');
 
-			const [url, body, cfg] = post.mock.calls[0];
-			expect(url).toBe(`${BASE_URL}/auth/passkey/register/begin`);
-			expect(body).toEqual({ tenantId: 'acme', inviteCode: 'invite-123' });
+			const [cfg] = request.mock.calls[0];
+			expect(cfg?.url).toBe(`${BASE_URL}/auth/passkey/register/begin`);
+			expect(cfg?.data).toEqual({ tenantId: 'acme', inviteCode: 'invite-123' });
 			expect(cfg?.headers).toMatchObject({ 'X-Tenant-ID': 'acme' });
 		});
 	});
 
 	describe('registerFinish', () => {
 		it('posts displayName, privateData and credential', async () => {
-			post.mockResolvedValue(okData(registerFinishData));
+			request.mockResolvedValue(okData(registerFinishData));
 
 			const res = await client.registerFinish(
 				'chal-2',
@@ -220,9 +221,9 @@ describe('AuthServerClient', () => {
 				'acme',
 			);
 
-			const [url, body] = post.mock.calls[0];
-			expect(url).toBe(`${BASE_URL}/auth/passkey/register/finish`);
-			expect(body).toMatchObject({
+			const [cfg] = request.mock.calls[0];
+			expect(cfg?.url).toBe(`${BASE_URL}/auth/passkey/register/finish`);
+			expect(cfg?.data).toMatchObject({
 				challengeId: 'chal-2',
 				displayName: 'Bob',
 				privateData: { some: 'privateData' },
@@ -233,13 +234,14 @@ describe('AuthServerClient', () => {
 
 	describe('logout', () => {
 		it('deletes the session with credentials and tenant headers', async () => {
-			del.mockResolvedValue(okData({}));
+			request.mockResolvedValue(okData({}));
 
 			await client.logout('acme');
 
-			expect(del).toHaveBeenCalledWith(
-				`${BASE_URL}/auth/session`,
+			expect(request).toHaveBeenCalledWith(
 				expect.objectContaining({
+					method: 'DELETE',
+					url: `${BASE_URL}/auth/session`,
 					withCredentials: true,
 					headers: expect.objectContaining({
 						'X-Token-Mode': 'session',

--- a/src/lib/auth/auth-server/AuthServerClient.test.ts
+++ b/src/lib/auth/auth-server/AuthServerClient.test.ts
@@ -232,14 +232,20 @@ describe('AuthServerClient', () => {
 	});
 
 	describe('logout', () => {
-		it('deletes the session with credentials', async () => {
+		it('deletes the session with credentials and tenant headers', async () => {
 			del.mockResolvedValue(okData({}));
 
-			await client.logout();
+			await client.logout('acme');
 
 			expect(del).toHaveBeenCalledWith(
 				`${BASE_URL}/auth/session`,
-				expect.objectContaining({ withCredentials: true }),
+				expect.objectContaining({
+					withCredentials: true,
+					headers: expect.objectContaining({
+						'X-Token-Mode': 'session',
+						'X-Tenant-ID': 'acme',
+					}),
+				}),
 			);
 		});
 	});

--- a/src/lib/auth/auth-server/AuthServerClient.ts
+++ b/src/lib/auth/auth-server/AuthServerClient.ts
@@ -186,8 +186,16 @@ export class AuthServerClient {
 		const request = (async () => {
 			const res = await this.#post(
 				this.#endpointToken,
-				{ aud, tac, tenant_id: tenantId, anonymous },
-				{ 'X-Token-Mode': 'session' },
+				{
+					aud,
+					tac,
+					tenant_id: tenantId,
+					anonymous,
+				},
+				{
+					'X-Token-Mode': 'session',
+					'X-Tenant-ID': tenantId,
+				},
 			);
 
 			const { success, data } = TokenResponseSchema.safeParse(res.data);

--- a/src/lib/auth/auth-server/AuthServerClient.ts
+++ b/src/lib/auth/auth-server/AuthServerClient.ts
@@ -214,9 +214,10 @@ export class AuthServerClient {
 		}
 	}
 
-	async logout(): Promise<void> {
-		await axios.delete(this.#url(this.#endpointSession), {
-			withCredentials: true,
+	async logout(tenantId: string): Promise<void> {
+		await this.#delete(this.#endpointSession, {
+			'X-Token-Mode': 'session',
+			'X-Tenant-ID': tenantId,
 		});
 	}
 
@@ -225,14 +226,32 @@ export class AuthServerClient {
 		body: object,
 		headers: Record<string, string> = {},
 	): Promise<AxiosResponse> {
-		return axios.post(this.#url(path), body, {
+		return this.#request('POST', path, headers, body);
+	}
+
+	async #delete(
+		path: string,
+		headers: Record<string, string> = {},
+	): Promise<AxiosResponse> {
+		return this.#request('DELETE', path, headers);
+	}
+
+	async #request(
+		method: 'GET' | 'POST' | 'DELETE',
+		path: string,
+		headers: Record<string, string>,
+		body?: object,
+	): Promise<AxiosResponse> {
+		return axios.request({
+			method,
+			url: this.#url(path),
 			headers: { 'Content-Type': 'application/json', ...headers },
 			withCredentials: true,
+			data: body,
 			transformRequest: (data) => jsonStringifyTaggedBinary(data),
 			transformResponse: transformTaggedResponse,
 		});
 	}
-
 
 	#url(path: string): string {
 		return new URL(path, this.#baseUrl).toString();


### PR DESCRIPTION
## Summary
The tenant id header was not being sent to the `/auth/token` endpoint. Our infra requires this header in order to route the request.
## Type of change
<!-- Check all that apply -->
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Documentation
- [ ] Tests
- [ ] Build/CI
- [ ] Chore

## Checklist
- [x] I self-reviewed my changes
- [ ] I added/updated tests (or explained why not)
- [ ] I updated documentation (if needed)
- [ ] I ran the relevant checks locally (lint/unit/integration)
- [ ] I verified backward compatibility / migration notes (if needed)
- [ ] I added monitoring/logging (if needed)

## Security checklist
<!-- For any PR that touches code, dependencies, or configuration -->
- [x] No secrets, credentials, or API keys are hardcoded
- [x] New dependencies have been reviewed for known vulnerabilities
- [x] User input is validated and sanitized where applicable
- [x] No new attack surface introduced without security review
- [x] PII/sensitive data handling follows data protection policies
- [ ] N/A — this PR does not affect code, deps, or configuration
