### PR TITLE
feat: DIIP v5 holder identifiers, authorization_details and credential status

### DIFF
--- a/src/components/Credentials/CredentialLayout.jsx
+++ b/src/components/Credentials/CredentialLayout.jsx
@@ -137,12 +137,12 @@ const CredentialLayout = ({ children, title = null, displayCredentialInfo = null
 				)}
 			</div>
 
-			{screenType === 'mobile' && vcEntity?.isExpired && (
+			{screenType === 'mobile' && vcEntity?.credentialStatus && (
 				<div className="bg-lm-orange-bg dark:bg-dm-orange-bg text-black mx-2 p-2 shadow-lg text-sm rounded-lg mb-4 flex items-center">
 					<div className="mr-2 ">
 						<TriangleAlert size={18} />
 					</div>
-					<p>{t('pageCredentials.details.expired')}</p>
+					<p>{t(`pageCredentials.details.${vcEntity.credentialStatus}`)}</p>
 				</div>
 			)}
 			<div className="mb-2">

--- a/src/components/Credentials/ExpiredRibbon.jsx
+++ b/src/components/Credentials/ExpiredRibbon.jsx
@@ -2,17 +2,33 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+/**
+ * Corner ribbon showing why a credential cannot currently be used.
+ *
+ * Covers the outcomes of the DIIP v5 validity and revocation algorithm: the validFrom /
+ * validUntil window, and the issuer's Token Status List.
+ */
+const STATUS_STYLES = {
+	expired: 'bg-lm-red dark:bg-dm-red',
+	revoked: 'bg-lm-red dark:bg-dm-red',
+	suspended: 'bg-lm-orange dark:bg-dm-orange',
+	notYetValid: 'bg-lm-orange dark:bg-dm-orange',
+};
+
 const ExpiredRibbon = ({ vcEntity, borderColor }) => {
 	const { t } = useTranslation();
 
+	// `credentialStatus` supersedes the older `isExpired` flag, which is kept in sync for
+	// call sites that have not moved over yet.
+	const status = vcEntity?.credentialStatus ?? (vcEntity?.isExpired ? 'expired' : null);
+	if (!status) {
+		return null;
+	}
+
 	return (
-		<>
-			{vcEntity && vcEntity.isExpired &&
-				<div className={`absolute bottom-0 right-0 text-white text-xs py-1 px-3 rounded-tl-lg rounded-br-2xl border ${borderColor ?? 'border-lm-gray-100 dark:border-dm-gray-900'} ${vcEntity.isExpired ? 'bg-lm-red dark:bg-dm-red' : 'bg-lm-green dark:bg-dm-green'}`}>
-					{t('expiredRibbon.expired')}
-				</div>
-			}
-		</>
+		<div className={`absolute bottom-0 right-0 text-white text-xs py-1 px-3 rounded-tl-lg rounded-br-2xl border ${borderColor ?? 'border-lm-gray-100 dark:border-dm-gray-900'} ${STATUS_STYLES[status] ?? STATUS_STYLES.expired}`}>
+			{t(`expiredRibbon.${status}`)}
+		</div>
 	);
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,13 @@
 import { type ClientMetaConfig } from '../config';
 import type { OIDFlowTransportType } from '@/lib/openid-flow/types/OIDFlowTypes';
-export type DidKeyVersion = "p256-pub" | "jwk_jcs-pub";
+/**
+ * How holder key pairs are turned into a DID.
+ *
+ * `jwk` produces a `did:jwk`, which DIIP v5 requires as the identifier of Holders. The two
+ * `did:key` variants predate it and stay supported so wallets that already hold credentials
+ * bound to a `did:key` keep working.
+ */
+export type DidKeyVersion = "jwk" | "p256-pub" | "jwk_jcs-pub";
 export type LogLevel = "error" | "info" | "warn" | "debug";
 
 type Config = ClientMetaConfig & Record<string, string | undefined>;
@@ -29,7 +36,8 @@ export const MODE = import.meta.env.MODE as 'development' | 'production' || 'pro
 export const APP_VERSION = import.meta.env.VITE_APP_VERSION;
 export const BASE_PATH = config.base_path || '/';
 export const BACKEND_URL = config.wallet_backend_url;
-export const DID_KEY_VERSION: DidKeyVersion = config.did_key_version as DidKeyVersion;
+// Defaults to did:jwk so a wallet is DIIP v5 compliant out of the box.
+export const DID_KEY_VERSION: DidKeyVersion = (config.did_key_version as DidKeyVersion) || "jwk";
 export const DISPLAY_CONSOLE = config.display_console;
 export const LOG_LEVEL: LogLevel = (config.log_level as LogLevel) || 'info';
 

--- a/src/context/CredentialsContext.ts
+++ b/src/context/CredentialsContext.ts
@@ -16,8 +16,18 @@ export type Instance = {
 	sigCount: number;
 }
 
+/**
+ * Why a credential cannot currently be used, or `null` when it can.
+ *
+ * These are the outcomes of the DIIP v5 validity and revocation algorithm: the `validFrom` /
+ * `validUntil` window, and the issuer's Token Status List.
+ */
+export type CredentialStatus = 'expired' | 'notYetValid' | 'revoked' | 'suspended' | null;
+
 export type ExtendedVcEntity = WalletStateCredential & {
 	parsedCredential: ParsedCredential;
+	credentialStatus: CredentialStatus;
+	/** @deprecated prefer `credentialStatus`; kept so existing call sites keep working. */
 	isExpired: boolean;
 	instances: Instance[];
 	sigCount: number; // calculate usage by parsing all presentation history

--- a/src/context/CredentialsContextProvider.tsx
+++ b/src/context/CredentialsContextProvider.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useContext, useRef, useEffect, useMemo } 
 import SessionContext from './SessionContext';
 import { initializeCredentialEngine } from "../lib/initializeCredentialEngine";
 import { AuthZENClient, AuthZENClientConfig, CredentialVerificationError, ParsedCredential } from "wallet-common";
-import CredentialsContext, { ExtendedVcEntity, Instance } from "./CredentialsContext";
+import CredentialsContext, { CredentialStatus, ExtendedVcEntity, Instance } from "./CredentialsContext";
 import { useOpenID4VCIHelper } from "@/lib/services/OpenID4VCIHelper";
 import { CurrentSchema } from '@/services/WalletStateSchema';
 import { logger } from '../logger';
@@ -10,6 +10,21 @@ import { BACKEND_URL } from '@/config';
 import { getTenantFromUrlPath } from '@/lib/tenant';
 import { useHttpClient } from '@/hooks/useHttpClient';
 import Spinner from '@/components/Shared/Spinner';
+
+/**
+ * Map the verification errors of the DIIP v5 validity and revocation algorithm onto the status a
+ * credential is shown with. Any other verification failure is not a status the user can act on,
+ * so it is left unset.
+ */
+function toCredentialStatus(error: CredentialVerificationError): CredentialStatus {
+	switch (error) {
+		case CredentialVerificationError.ExpiredCredential: return 'expired';
+		case CredentialVerificationError.NotYetValidCredential: return 'notYetValid';
+		case CredentialVerificationError.RevokedCredential: return 'revoked';
+		case CredentialVerificationError.SuspendedCredential: return 'suspended';
+		default: return null;
+	}
+}
 
 type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
@@ -162,13 +177,15 @@ export const CredentialsContextProvider = ({ children }: React.PropsWithChildren
 						return null;
 					}
 					const result = await credentialVerifyingEngine.verify({ rawCredential: credential.data, opts: {} });
+					const credentialStatus = result.success === false ? toCredentialStatus(result.error) : null;
 
 					// Attach the instances array from the map and add parsedCredential
 					return {
 						...credential,
 						instances: instancesMap[credential.batchId],
 						parsedCredential,
-						isExpired: result.success === false && result.error === CredentialVerificationError.ExpiredCredential,
+						credentialStatus,
+						isExpired: credentialStatus === 'expired',
 						sigCount: instancesMap[credential.batchId].reduce((acc: number, curr: Instance) =>
 							acc + curr.sigCount
 							, 0),

--- a/src/hooks/useOID4VCIFlow.ts
+++ b/src/hooks/useOID4VCIFlow.ts
@@ -1,7 +1,7 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useOIDFlowTransportSafe } from '@/context/OIDFlowTransportContext';
 import OpenID4VCIContext from '@/context/OpenID4VCIContext';
-import { CredentialOfferSchema, VerifiableCredentialFormat } from 'wallet-common';
+import { CredentialOfferSchema, VerifiableCredentialFormat, detectCredentialFormat } from 'wallet-common';
 import type { OID4VCIFlowResult } from '@/lib/openid-flow/types/OID4VCITypes';
 import type { OIDFlowActiveTransportType, OIDFlowProgressEvent } from '@/lib/openid-flow/types/OIDFlowTypes';
 import { DISPLAY_ISSUANCE_WARNINGS, OPENID4VCI_REDIRECT_URI } from '@/config';
@@ -479,6 +479,7 @@ export function useOID4VCIFlow(options: UseOID4VCIFlowOptions = {}): UseOID4VCIF
 				if (
 					batchFormat === VerifiableCredentialFormat.VC_SDJWT ||
 					batchFormat === VerifiableCredentialFormat.DC_SDJWT ||
+					batchFormat === VerifiableCredentialFormat.W3C_VCDM_SDJWT ||
 					batchFormat === VerifiableCredentialFormat.MSO_MDOC
 				) {
 					kid = await deriveHolderKidFromCredential(c.credential, batchFormat) ?? '';
@@ -607,7 +608,11 @@ function inferFormatFromCredential(credential: string): VerifiableCredentialForm
 		const header = JSON.parse(atob(headerB64.replace(/-/g, '+').replace(/_/g, '/')));
 
 		if (header.typ === 'dc+sd-jwt') return VerifiableCredentialFormat.DC_SDJWT;
-		if (header.typ === 'vc+sd-jwt') return VerifiableCredentialFormat.VC_SDJWT;
+		if (header.typ === 'vc+sd-jwt') {
+			// VC-JOSE-COSE secures W3C VCDM 2.0 credentials with this same typ; the payload
+			// tells them apart.
+			return detectCredentialFormat(credential) ?? VerifiableCredentialFormat.VC_SDJWT;
+		}
 		if (header.typ === 'JWT' || header.typ === 'jwt_vc_json') return VerifiableCredentialFormat.JWT_VC_JSON;
 	} catch (error) {
 		logger.debug('Failed to parse credential as JWT for format inference', { error });

--- a/src/hooks/useOIDFlowSignHandler.ts
+++ b/src/hooks/useOIDFlowSignHandler.ts
@@ -218,8 +218,11 @@ async function createVpToken(
 	const { nonce, audience, responseUri, origin, verifierJwkThumbprint } = params;
 
 	switch (detectCredentialFormat(credentialRaw)) {
+			// W3C_VCDM_SDJWT is a W3C VCDM 2.0 credential secured with SD-JWT: presented through
+			// the same SD-JWT + KB-JWT envelope, only its payload vocabulary differs.
 			case VerifiableCredentialFormat.DC_SDJWT:
 			case VerifiableCredentialFormat.VC_SDJWT:
+			case VerifiableCredentialFormat.W3C_VCDM_SDJWT:
 			case VerifiableCredentialFormat.JWT_VC_JSON:
 				return await createVpTokenFromSdJwt(
 					keystore,

--- a/src/lib/initializeCredentialEngine.ts
+++ b/src/lib/initializeCredentialEngine.ts
@@ -1,6 +1,6 @@
 import { CLOCK_TOLERANCE, VCT_REGISTRY_URL, DELEGATE_TRUST_TO_BACKEND } from "../config";
 import { IHttpClient } from "./interfaces/IHttpClient";
-import { ParsingEngine, SDJWTVCParser, PublicKeyResolverEngine, SDJWTVCVerifier, MsoMdocParser, MsoMdocVerifier, JWTVCJSONParser, JWTVCJSONVerifier, VerifyingEngine, IAuthZENClient } from "wallet-common";
+import { ParsingEngine, SDJWTVCParser, PublicKeyResolverEngine, SDJWTVCVerifier, MsoMdocParser, MsoMdocVerifier, JWTVCJSONParser, JWTVCJSONVerifier, VCDMSDJWTParser, DidPublicKeyResolver, VerifyingEngine, IAuthZENClient } from "wallet-common";
 import { IOpenID4VCIHelper } from "./interfaces/IOpenID4VCIHelper";
 import { createVctDocumentResolutionEngine, VctDocumentProvider, VctResolutionErrors, ok, err } from 'wallet-common';
 import { logger } from '@/logger';
@@ -54,10 +54,16 @@ export async function initializeCredentialEngine(
 
 	const credentialParsingEngine = ParsingEngine();
 	credentialParsingEngine.register(SDJWTVCParser({ context: ctx, httpClient: httpProxy, authzenClient }));
+	// W3C VCDM 2.0 secured with SD-JWT, required by DIIP v5. Registered after SDJWTVCParser,
+	// which declines VCDM payloads so they reach this parser.
+	credentialParsingEngine.register(VCDMSDJWTParser({ context: ctx, httpClient: httpProxy, authzenClient }));
 	credentialParsingEngine.register(MsoMdocParser({ context: ctx, httpClient: httpProxy, authzenClient }));
 	credentialParsingEngine.register(JWTVCJSONParser({ context: ctx, httpClient: httpProxy, authzenClient }));
 
 	const pkResolverEngine = PublicKeyResolverEngine();
+	// DIIP v5 identifies Issuers by did:jwk or did:web, so credentials signed by a DID-identified
+	// issuer resolve their key from the DID document's assertionMethod.
+	pkResolverEngine.register(DidPublicKeyResolver({ httpClient: httpProxy }));
 	const credentialVerifyingEngine = VerifyingEngine();
 	credentialVerifyingEngine.register(SDJWTVCVerifier({ context: ctx, pkResolverEngine: pkResolverEngine, httpClient: httpProxy }));
 	credentialVerifyingEngine.register(MsoMdocVerifier({ context: ctx, pkResolverEngine: pkResolverEngine }));

--- a/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
+++ b/src/lib/openid-flow/transports/OIDFlowWebSocketTransport.ts
@@ -12,7 +12,7 @@
  * - Better error handling with flow state
  */
 
-import { TrustStatus as TrustStatusEnum } from 'wallet-common';
+import { TrustStatus as TrustStatusEnum, parseClientIdScheme } from 'wallet-common';
 import type { IOIDFlowTransport } from '../types/IOIDFlowTransport';
 import type {
 	OIDFlowRequest,
@@ -776,13 +776,13 @@ export class OIDFlowWebSocketTransport implements IOIDFlowTransport {
 					});
 					break;
 				case 'credential_verifier':
-					const scheme = (request.context?.client_id_scheme as string) || 'x509_san_dns';
 					const clientId = request.subject_id;
-
-					let identifier = clientId;
-					if (scheme === 'x509_san_dns' && clientId.startsWith('x509_san_dns:')) {
-						identifier = clientId.slice('x509_san_dns:'.length);
-					}
+					// Derive the scheme from the client_id itself so OID4VP Client Identifier
+					// Prefixes are handled — DIIP v5 requires the `did` scheme, which arrives as
+					// `decentralized_identifier:did:web:…`. An explicit hint from the backend wins.
+					const parsedScheme = parseClientIdScheme(clientId);
+					const scheme = (request.context?.client_id_scheme as string) || parsedScheme.scheme;
+					const identifier = scheme === parsedScheme.scheme ? parsedScheme.identifier : clientId;
 
 					result = await this.trustEvaluators.evaluateVerifierTrust({
 						clientIdScheme: {

--- a/src/lib/services/OpenID4VCI/OpenID4VCI.ts
+++ b/src/lib/services/OpenID4VCI/OpenID4VCI.ts
@@ -9,6 +9,7 @@ import { useOpenID4VCIHelper } from '../OpenID4VCIHelper';
 import { GrantType, TokenRequestError, useTokenRequest } from './OAuth/TokenRequest';
 import { useCredentialRequest } from './CredentialRequest';
 import { CurrentSchema } from '@/services/WalletStateSchema';
+import { resolveCnfKid } from '@/services/keystore';
 import SessionContext from '@/context/SessionContext';
 import { useTenant } from '@/context/TenantContext';
 import { CredentialConfigurationSupported, CredentialOfferSchema, VerifiableCredentialFormat } from 'wallet-common';
@@ -54,6 +55,7 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 	switch (format) {
 		case VerifiableCredentialFormat.VC_SDJWT:
 		case VerifiableCredentialFormat.DC_SDJWT:
+		case VerifiableCredentialFormat.W3C_VCDM_SDJWT:
 		case VerifiableCredentialFormat.JWT_VC_JSON: {
 			const payload = credential.split('.')[1];
 			if (!payload) {
@@ -61,14 +63,12 @@ export const deriveHolderKidFromCredential = async (credential: string, format: 
 			}
 			try {
 				const decoded = JSON.parse(textDecoder.decode(fromBase64Url(payload)));
-				const cnf = decoded.cnf as { jwk?: jose.JWK } | undefined;
-				if (cnf?.jwk) {
-					return jose.calculateJwkThumbprint(cnf.jwk, "sha256");
-				}
+				const cnf = decoded.cnf as { jwk?: jose.JWK, kid?: string } | undefined;
+				// DIIP v5 binds the holder by `cnf.kid`; `cnf.jwk` covers did:key credentials.
+				return (await resolveCnfKid(cnf)) ?? undefined;
 			} catch {
 				return undefined;
 			}
-			return undefined;
 		}
 		case VerifiableCredentialFormat.MSO_MDOC: {
 			const credentialBytes = fromBase64Url(credential);
@@ -642,14 +642,35 @@ export function useOpenID4VCI({ errorCallback, showPopupConsent, showMessagePopu
 			const userHandleB64u = keystore.getUserHandleB64u();
 			const state = btoa(JSON.stringify({ userHandleB64u: userHandleB64u, id: generateRandomIdentifier(12) })).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 
+			// DIIP v5 requires Wallets to support both ways of asking for a specific credential
+			// type: `authorization_details` with a `credential_configuration_id`, and `scope`.
+			// `authorization_details` is the structured form and the one Issuer Agents must
+			// support, so send it whenever the Authorization Server advertises support — and
+			// always when the credential configuration declares no scope to fall back on.
+			const authorizationDetailsSupported =
+				authzServerMetadata.authzServerMetadata.authorization_details_types_supported?.includes("openid_credential")
+				?? undefined;
+			const useAuthorizationDetails = authorizationDetailsSupported !== false || !scope;
+
 			// OAuth params
 			const params: Record<string, string> = {
-				scope,
 				response_type: "code",
 				client_id: clientId.client_id,
 				state,
 				redirect_uri: redirectUri
 			};
+			if (useAuthorizationDetails) {
+				params["authorization_details"] = JSON.stringify([{
+					type: "openid_credential",
+					credential_configuration_id: credentialConfigurationId,
+				}]);
+			}
+			if (scope) {
+				params["scope"] = scope;
+			}
+			if (!useAuthorizationDetails && !scope) {
+				throw new Error(`Credential configuration ${credentialConfigurationId} declares no scope and the Authorization Server does not support authorization_details`);
+			}
 			if (issuer_state) {
 				params["issuer_state"] = issuer_state;
 			}

--- a/src/lib/services/TrustEvaluator.ts
+++ b/src/lib/services/TrustEvaluator.ts
@@ -3,7 +3,7 @@
  *
  * This module bridges the wallet-common AuthZEN client with the
  * wallet trust evaluation interfaces, enabling trust evaluation for:
- * - Verifiers (OpenID4VP): did:web, https, x509_san_dns schemes
+ * - Verifiers (OpenID4VP): did:jwk, did:web, https, x509_san_dns schemes
  * - Issuers (OpenID4VCI): credential issuer trust evaluation
  *
  * All trust decisions are delegated to the wallet backend's AuthZEN proxy,
@@ -19,6 +19,7 @@ import {
 	DIDDocument,
 	DIDResolver,
 	ClientIdScheme,
+	resolveDidJwk,
 } from 'wallet-common';
 import type { HttpClient } from 'wallet-common';
 import { logger } from '@/logger';
@@ -373,6 +374,13 @@ export function createDIDResolver(config: TrustEvaluatorConfig): DIDResolver {
 	const authzenClient = AuthZENClient(clientConfig);
 
 	return async (did: string): Promise<DIDResolutionResult> => {
+		// did:jwk encodes the key in the identifier itself, so it resolves offline and there is
+		// nothing for the backend to look up. DIIP v5 requires supporting it alongside did:web.
+		if (did.startsWith('did:jwk:')) {
+			logger.debug('Resolving did:jwk locally:', did);
+			return resolveDidJwk(did);
+		}
+
 		logger.debug('Resolving DID via AuthZEN backend:', did);
 
 		const result = await authzenClient.resolve(did);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,7 +59,10 @@
 		"legendRequired": "Required"
 	},
 	"expiredRibbon": {
-		"expired": "Expired"
+		"expired": "Expired",
+		"notYetValid": "Not yet valid",
+		"revoked": "Revoked",
+		"suspended": "Suspended"
 	},
 	"issuance": {
 		"credentialsHaveErrors": "Errors have been found while verifying the credential you are trying to receive.",
@@ -301,7 +304,10 @@
 		"details": {
 			"availableUsages": "Available Usages",
 			"description": "View all the information about the chosen credential",
-			"expired": "This Credential has been expired"
+			"expired": "This Credential has been expired",
+			"notYetValid": "This Credential is not valid yet",
+			"revoked": "This Credential has been revoked by its issuer",
+			"suspended": "This Credential has been suspended by its issuer"
 		},
 		"presentationsTitle": "Presentations",
 		"slideButtonAriaLabelDisable": "No {{direction}} credential",

--- a/src/services/keystore.test.ts
+++ b/src/services/keystore.test.ts
@@ -6,6 +6,7 @@ import * as util from '@cef-ebsi/key-did-resolver/dist/util.js';
 import * as keystore from "./keystore.js";
 import { byteArrayEquals, fromBase64, jsonParseTaggedBinary, toBase64, toBase64Url } from "../util";
 import { DidKeyVersion } from "../config.js";
+import { findPublicKeyInDidDocument, resolveDidJwk } from "wallet-common";
 
 
 async function asyncAssertThrows(fn: () => Promise<any>, message: string): Promise<unknown> {
@@ -267,6 +268,32 @@ describe("The keystore", () => {
 		};
 		it("p256-pub.", async () => test("p256-pub"));
 		it("jwk_jcs-pub.", async () => test("jwk_jcs-pub"));
+
+		// DIIP v5 requires the `jwt` proof type to carry the Holder's did:jwk as `iss` and to
+		// name the key with a `kid` from the DID document instead of embedding a `jwk` header.
+		it("jwk (did:jwk).", async () => {
+			const [{ proof_jwts }, [newPrivateData, newMainKey]] = await keystore.generateOpenid4vciProofs(
+				[privateData, mainKey],
+				"jwk",
+				"test-nonce",
+				"test-audience",
+				"test-issuer",
+			);
+			const [, , calculatedState] = await keystore.openPrivateData(newMainKey, newPrivateData);
+			const { kid, did, publicKey: publicKeyJwk } = calculatedState.keypairs[0].keypair;
+
+			assert.isTrue(did.startsWith("did:jwk:"));
+			assert.equal(kid, `${did}#0`);
+
+			const publicKey = await jose.importJWK(publicKeyJwk);
+			const { protectedHeader, payload } = await jose.jwtVerify(proof_jwts[0], publicKey, {
+				audience: "test-audience",
+			});
+			assert.equal(protectedHeader.kid, kid);
+			assert.isUndefined(protectedHeader.jwk);
+			assert.equal(payload.iss, did);
+			assert.equal(payload.nonce, "test-nonce");
+		});
 	});
 
 	describe("can generate and store new credential keypairs on request with DID key version", async () => {
@@ -294,6 +321,93 @@ describe("The keystore", () => {
 		};
 		it("p256-pub.", async () => test("p256-pub"));
 		it("jwk_jcs-pub.", async () => test("jwk_jcs-pub"));
+		it("jwk.", async () => test("jwk"));
+	});
+
+	describe("resolveCnfKid", () => {
+		it("returns a DIIP v5 cnf.kid unchanged", async () => {
+			const kid = "did:jwk:eyJrdHkiOiJFQyJ9#0";
+			assert.equal(await keystore.resolveCnfKid({ kid }), kid);
+		});
+
+		it("falls back to the JWK thumbprint for a cnf.jwk", async () => {
+			const jwk = {
+				kty: "EC",
+				crv: "P-256",
+				x: "acbIQiuMs3i8_uszEjJ2tpTtRM4EU3yz91PH6CdH2V0",
+				y: "_KcyLj9vWMptnmKtm46GqDz8wf74I5LKgrl2GzH3nSE",
+			};
+			assert.equal(await keystore.resolveCnfKid({ jwk }), await jose.calculateJwkThumbprint(jwk, "sha256"));
+		});
+
+		it("prefers kid when both are present", async () => {
+			assert.equal(await keystore.resolveCnfKid({ kid: "did:jwk:abc#0", jwk: { kty: "EC" } }), "did:jwk:abc#0");
+		});
+
+		it("returns null when the credential has no holder binding", async () => {
+			assert.isNull(await keystore.resolveCnfKid(undefined));
+			assert.isNull(await keystore.resolveCnfKid({}));
+		});
+	});
+
+	// The keystore mints did:jwk identifiers and wallet-common resolves them; nothing else covers
+	// that seam, and a mismatch would only surface as an unverifiable credential at issuance time.
+	describe("did:jwk round trip with the wallet-common resolver", () => {
+		it("resolves a keystore-generated did:jwk back to the signing key", async () => {
+			const privateData: keystore.AsymmetricEncryptedContainer = jsonParseTaggedBinary('{"mainKey":{"publicKey":{"importKey":{"format":"raw","keyData":{"$b64u":"BDlRO3IEL-F27glDVct16_imvjenX1-EmTigMk2YHpmXh8j_sw156BudaNxXDH2QQqUldVMxNRrto4aEUhCfRaI"},"algorithm":{"name":"ECDH","namedCurve":"P-256"}}},"unwrapKey":{"format":"raw","unwrapAlgo":"AES-KW","unwrappedKeyAlgo":{"name":"AES-GCM","length":256}}},"jwe":"eyJhbGciOiJBMjU2R0NNS1ciLCJlbmMiOiJBMjU2R0NNIiwiaXYiOiJ2a2g0N0praHVZTEhMdVNDIiwidGFnIjoiSmlmOUM2TWVhbkZnNFpobS12anBNdyJ9.V1kqO2rF2FLWIMunZChEJfiiVs7QomiuQeR5BghozHk.snCD6eGCTQI5qkot.RuJHw4jUSrb5I5FMVujO.UpvJ6zQM3RTE6ynfs7z7nw","prfKeys":[{"credentialId":{"$b64u":"L36kS042hbgmDGkvMt_8abWT0n93IxW5HQB5YKfq0W0nPZQDehu07Qk9L0Aw5C76"},"prfSalt":{"$b64u":"_JMrkAUh64gigXqI--DWoUlgP3zqTCLS2uQASAhutxA"},"hkdfSalt":{"$b64u":"j_sssVxuQMTXzzUj5899uAxVVIEf87FFT6Vrn-ckPxw"},"hkdfInfo":{"$b64u":"ZURpcGxvbWFzIFBSRg"},"algorithm":{"name":"AES-GCM","length":256},"keypair":{"publicKey":{"importKey":{"format":"raw","keyData":{"$b64u":"BAnaAJXU1ja9ddHcWBVqDpLBQWY4wF3KB1Av92rqFdfWx6XWKSzNLsgKlrZnLJN7xo3pOwhJTXAXqxowPykzvx8"},"algorithm":{"name":"ECDH","namedCurve":"P-256"}}},"privateKey":{"unwrapKey":{"format":"jwk","wrappedKey":{"$b64u":"FWhWa7XO_Mqjpr0FhyR_HZcJmgcpoPIsOSdPllVNmsGnnALJ6rj1278lxTW-HEOAsdxUK2K7njciF2e7L4nsGu0ZJ4LqsXkD7a47YLJ75hg9nH1kesbPunyS7rGBsVtKI9WxiZYxDwhiIqIPYRDGJbUXJQG-zunxo1KERsu4me_rsBmOuwqfesDvMllrm1wTY-R0h7UhIpFa2wTCXmW7pRPx3Pbvw7GAhWBBd6hpvWsUsOtCGSN9ujw6IUi5itB8xAcMCB2KbRuCicJa0MCsnyOOtUnsG-YzJFr4W-0FNT8UGvM"},"unwrapAlgo":{"name":"AES-GCM","iv":{"$b64u":"MbbvhJZyE8YP710b"}},"unwrappedKeyAlgo":{"name":"ECDH","namedCurve":"P-256"}}}},"unwrapKey":{"wrappedKey":{"$b64u":"aTU0F0u6QJG-tJ-jDXKe2noFVGb8QPri3GzprVaV0UcPEAegAU2tzw"},"unwrappingKey":{"deriveKey":{"algorithm":{"name":"ECDH"},"derivedKeyAlgorithm":{"name":"AES-KW","length":256}}}}}]}');
+			const mockCredential = mockPrfCredential({
+				id: privateData.prfKeys[0].credentialId,
+				prfOutput: fromBase64("2WEuykvYBxHGT2RCAoVrsPnkUl+T/tOQZbliln7bNmM="),
+			});
+			const [{ mainKey },] = await keystore.unlockPrf(privateData, mockCredential, async () => false);
+
+			const [{ proof_jwts }, [newPrivateData, newMainKey]] = await keystore.generateOpenid4vciProofs(
+				[privateData, mainKey], "jwk", "nonce", "https://issuer.example", "client-id",
+			);
+			const [, , calculatedState] = await keystore.openPrivateData(newMainKey, newPrivateData);
+			const { did } = calculatedState.keypairs[0].keypair;
+
+			// Resolve the DID exactly as an issuer verifying the proof would.
+			const resolution = resolveDidJwk(did);
+			assert.isTrue(resolution.resolved);
+			const jwk = findPublicKeyInDidDocument(resolution.didDocument!, `${did}#0`, "authentication");
+			assert.isOk(jwk);
+
+			// The resolved key must verify the proof the keystore just signed.
+			// wallet-common bundles its own copy of jose, so the JWK type is nominally distinct.
+			const { payload } = await jose.jwtVerify(proof_jwts[0], await jose.importJWK(jwk as jose.JWK, "ES256"));
+			assert.equal(payload.iss, did);
+		});
+	});
+
+	describe("findKeypairByKid", () => {
+		const publicKey = {
+			kty: "EC",
+			crv: "P-256",
+			x: "acbIQiuMs3i8_uszEjJ2tpTtRM4EU3yz91PH6CdH2V0",
+			y: "_KcyLj9vWMptnmKtm46GqDz8wf74I5LKgrl2GzH3nSE",
+		};
+		const stateWithKid = (kid: string) => ({
+			keypairs: [{ kid, keypair: { kid, did: "did:jwk:x", alg: "ES256", publicKey, privateKey: {} } }],
+		} as any);
+
+		it("matches a key pair by its stored kid", async () => {
+			const found = await keystore.findKeypairByKid(stateWithKid("did:jwk:x#0"), "did:jwk:x#0");
+			assert.isOk(found);
+		});
+
+		// mdoc device keys and SD-JWT `cnf.jwk` can only be addressed by thumbprint, so a wallet
+		// configured for did:jwk must still find the key pairs those credentials are bound to.
+		it("falls back to the thumbprint when the key pair has a did:jwk kid", async () => {
+			const thumbprint = await jose.calculateJwkThumbprint(publicKey as jose.JWK, "sha256");
+			const found = await keystore.findKeypairByKid(stateWithKid("did:jwk:x#0"), thumbprint);
+			assert.isOk(found);
+			assert.deepEqual(found?.publicKey, publicKey);
+		});
+
+		it("returns null when nothing matches", async () => {
+			assert.isNull(await keystore.findKeypairByKid(stateWithKid("did:jwk:x#0"), "no-such-kid"));
+		});
 	});
 
 	it("can automatically upgrade a symmetric PRF key to an asymmetric key.", async () => {

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1136,14 +1136,90 @@ async function addNewCredentialKeypairs(
 	};
 }
 
+/**
+ * Build a `did:jwk` from a public key.
+ *
+ * The method-specific identifier is the base64url-encoded JWK, and the DID document's single
+ * verification method is `<did>#0`.
+ *
+ * @see https://github.com/quartzjer/did-jwk/blob/main/spec.md
+ */
+async function createDidJwk(publicKey: CryptoKey): Promise<string> {
+	const publicKeyJwk = await crypto.subtle.exportKey("jwk", publicKey) as JWK;
+	// Strip the WebCrypto bookkeeping that is not part of the key itself, so the same key always
+	// yields the same DID.
+	const { ext, key_ops, ...jwk } = publicKeyJwk as JWK & { ext?: boolean, key_ops?: string[] };
+	return `did:jwk:${toBase64Url(new TextEncoder().encode(JSON.stringify(jwk)))}`;
+}
+
 async function createDid(publicKey: CryptoKey, didKeyVersion: DidKeyVersion): Promise<string> {
-	if (didKeyVersion === "p256-pub") {
+	if (didKeyVersion === "jwk") {
+		return createDidJwk(publicKey);
+	} else if (didKeyVersion === "p256-pub") {
 		const { didKeyString } = await createW3CDID(publicKey);
 		return didKeyString;
 	} else if (didKeyVersion === "jwk_jcs-pub") {
 		const publicKeyJwk = await crypto.subtle.exportKey("jwk", publicKey);
 		return didUtil.createDid(publicKeyJwk as JWK);
 	}
+	throw new Error(`Unsupported DID key version: ${didKeyVersion}`);
+}
+
+/**
+ * The `kid` a credential key pair is addressed by.
+ *
+ * For `did:jwk` this is the DID URL of the key's verification method — DIIP v5 requires the
+ * `cnf` holder binding to carry a `kid` from the holder's `authentication` relationship, and
+ * `#0` is the only verification method a did:jwk document has. The `did:key` versions keep
+ * using the JWK thumbprint they have always used.
+ */
+async function deriveKidForDid(publicKey: CryptoKey, did: string, didKeyVersion: DidKeyVersion): Promise<string> {
+	if (didKeyVersion === "jwk") {
+		return `${did}#0`;
+	}
+	const pubKey = await crypto.subtle.exportKey("jwk", publicKey);
+	return jose.calculateJwkThumbprint(pubKey as JWK, "sha256");
+}
+
+/**
+ * The local `kid` a credential's `cnf` claim binds it to.
+ *
+ * DIIP v5 binds the Holder with a `cnf.kid` naming a verification method of their DID document,
+ * which is exactly the `kid` stored alongside a `did:jwk` key pair. Credentials issued against
+ * the older `did:key` versions carry `cnf.jwk` instead, and are addressed by JWK thumbprint.
+ */
+/**
+ * Find a stored credential key pair by the `kid` a credential refers to it by.
+ *
+ * A key pair's `kid` depends on `DID_KEY_VERSION`: a DID URL for did:jwk, a JWK thumbprint for
+ * the did:key versions. Formats that identify the holder key by value rather than by name — mdoc
+ * device keys, and SD-JWT `cnf.jwk` — can only produce a thumbprint, so fall back to comparing
+ * thumbprints of the stored public keys. Without this, a wallet configured for did:jwk could not
+ * present the mdoc credentials it already holds.
+ */
+export async function findKeypairByKid(calculatedState: WalletState, kid: string): Promise<CredentialKeyPair | null> {
+	const direct = calculatedState.keypairs.find((k) => k.kid === kid);
+	if (direct) {
+		return direct.keypair;
+	}
+
+	for (const { keypair } of calculatedState.keypairs) {
+		const thumbprint = await jose.calculateJwkThumbprint(keypair.publicKey as JWK, "sha256").catch(() => null);
+		if (thumbprint === kid) {
+			return keypair;
+		}
+	}
+	return null;
+}
+
+export async function resolveCnfKid(cnf: { jwk?: JWK, kid?: string } | undefined): Promise<string | null> {
+	if (cnf?.kid) {
+		return cnf.kid;
+	}
+	if (cnf?.jwk) {
+		return jose.calculateJwkThumbprint(cnf.jwk, "sha256");
+	}
+	return null;
 }
 
 export async function signJwtPresentation([privateData, mainKey, calculatedState]: [PrivateData, CryptoKey, WalletState], nonce: string, audience: string, verifiableCredentials: any[], transactionDataResponseParams?: { transaction_data_hashes: string[], transaction_data_hashes_alg: string[] }): Promise<{ vpjwt: string }> {
@@ -1156,19 +1232,20 @@ export async function signJwtPresentation([privateData, mainKey, calculatedState
 	}
 
 	const inputJwt = await SDJwt.fromEncode(verifiableCredentials[0], hasher);
-	const { cnf } = inputJwt.jwt.payload as { cnf?: { jwk?: JWK } };
+	const { cnf } = inputJwt.jwt.payload as { cnf?: { jwk?: JWK, kid?: string } };
 
-	if (!cnf?.jwk) {
-		throw new Error("Holder public key could not be resolved from cnf.jwk attribute");
+	const kid = await resolveCnfKid(cnf);
+	if (!kid) {
+		throw new Error("Holder public key could not be resolved from the cnf claim");
 	}
 
-	const kid = await jose.calculateJwkThumbprint(cnf.jwk, "sha256");
-
-	const keypair = calculatedState.keypairs.filter((k) => k.kid === kid)[0];
+	// An issuer may bind by `cnf.jwk` even when this wallet names its keys by did:jwk URL, so the
+	// lookup has to tolerate either identifier.
+	const keypair = await findKeypairByKid(calculatedState, kid);
 	if (!keypair) {
 		throw new Error("Key pair not found for kid (key ID): " + kid);
 	}
-	const { alg, privateKey } = keypair.keypair;
+	const { alg, privateKey } = keypair;
 	const importedPrivateKey = await crypto.subtle.importKey(
 		'jwk',
 		privateKey,
@@ -1179,18 +1256,20 @@ export async function signJwtPresentation([privateData, mainKey, calculatedState
 	const sdJwt = verifiableCredentials[0];
 	const sd_hash = toBase64Url(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(sdJwt)));
 	// Build a public-key-only JWK for the KB-JWT header (strip any private key material)
-	const { d: _, ...publicJwk } = cnf.jwk as JWK & { d?: string };
+	const { d: _, ...publicJwk } = (cnf.jwk ?? keypair.publicKey) as JWK & { d?: string };
 	const kbJWT = await new SignJWT({
 		nonce,
 		aud: audience,
 		sd_hash,
 		...transactionDataResponseParams,
 	}).setIssuedAt()
-		.setProtectedHeader({
-			typ: "kb+jwt",
-			alg: alg,
-			jwk: publicJwk,
-		})
+		.setProtectedHeader(
+			// When the credential binds the holder by `kid` (DIIP v5), the KB-JWT names the same
+			// verification method rather than re-embedding the key.
+			cnf.jwk
+				? { typ: "kb+jwt", alg: alg, jwk: publicJwk }
+				: { typ: "kb+jwt", alg: alg, kid: kid },
+		)
 		.sign(importedPrivateKey);
 
 	const jws = sdJwt + kbJWT;
@@ -1205,26 +1284,28 @@ export async function generateOpenid4vciProofs(
 	issuer: string,
 	numberOfKeyPairs: number = 1
 ): Promise<[{ proof_jwts: string[] }, OpenedContainer]> {
-	const deriveKid = async (publicKey: CryptoKey) => {
-		const pubKey = await crypto.subtle.exportKey("jwk", publicKey);
-		const jwkThumbprint = await jose.calculateJwkThumbprint(pubKey as JWK, "sha256");
-		return jwkThumbprint;
-	};
+	const deriveKid = (publicKey: CryptoKey, did: string) => deriveKidForDid(publicKey, did, didKeyVersion);
 	const { privateKeys, newPrivateData, keypairs } = await addNewCredentialKeypairs(container, didKeyVersion, deriveKid, numberOfKeyPairs);
+
+	const usesDidJwk = didKeyVersion === "jwk";
 
 	const proof_jwts = await Promise.all(keypairs.map(async (keypair, index) => {
 		const privateKey = privateKeys[index];
 		const jws: string = await new SignJWT({
 			nonce: nonce,
 			aud: audience,
-			iss: issuer,
+			// DIIP v5: the `jwt` proof type carries the Holder's did:jwk as the `iss` value.
+			// Without did:jwk there is no DID to name, so the caller-supplied client_id stands in.
+			iss: usesDidJwk ? keypair.did : issuer,
 		})
 			.setIssuedAt()
-			.setProtectedHeader({
-				alg: keypair.alg,
-				typ: "openid4vci-proof+jwt",
-				jwk: { ...keypair.publicKey, kid: keypair.kid, key_ops: ['verify'] } as JWK,
-			})
+			.setProtectedHeader(
+				usesDidJwk
+					// DIIP v5 identifies the proof key by a `kid` from the Holder's DID document
+					// rather than embedding the key in the header.
+					? { alg: keypair.alg, typ: "openid4vci-proof+jwt", kid: keypair.kid }
+					: { alg: keypair.alg, typ: "openid4vci-proof+jwt", jwk: { ...keypair.publicKey, kid: keypair.kid, key_ops: ['verify'] } as JWK },
+			)
 			.sign(privateKey);
 		return jws;
 	}));
@@ -1238,11 +1319,7 @@ export async function generateKeypairs(
 	didKeyVersion: DidKeyVersion,
 	numberOfKeyPairs: number = 1
 ): Promise<[{ keypairs: CredentialKeyPair[] }, OpenedContainer]> {
-	const deriveKid = async (publicKey: CryptoKey) => {
-		const pubKey = await crypto.subtle.exportKey("jwk", publicKey);
-		const jwkThumbprint = await jose.calculateJwkThumbprint(pubKey as JWK, "sha256");
-		return jwkThumbprint;
-	};
+	const deriveKid = (publicKey: CryptoKey, did: string) => deriveKidForDid(publicKey, did, didKeyVersion);
 	const { newPrivateData, keypairs } = await addNewCredentialKeypairs(container, didKeyVersion, deriveKid, numberOfKeyPairs);
 	return [{ keypairs }, newPrivateData];
 }
@@ -1389,13 +1466,13 @@ export async function generateDeviceResponseWithProximity([privateData, mainKey,
 	const devicePublicKeyJwk = COSEKeyToJWK(deviceKey);
 	const kid = await jose.calculateJwkThumbprint(devicePublicKeyJwk, "sha256");
 
-	// get the keypair based on the jwk Thumbprint
-	const keypair = calculatedState.keypairs.filter((k) => k.kid === kid)[0];
+	// get the keypair the mdoc's device key belongs to
+	const keypair = await findKeypairByKid(calculatedState, kid);
 	if (!keypair) {
 		throw new Error("Key pair not found for kid (key ID): " + kid);
 	}
 
-	const { alg, privateKey } = keypair.keypair;
+	const { alg, privateKey } = keypair;
 	const privateKeyJwk = privateKey;
 
 	const options = getCborEncodeDecodeOptions();


### PR DESCRIPTION
The `wallet-frontend` half of DIIP v5 compliance for the SIROS ID wallet.

> **🚧 Blocked on sirosfoundation/wallet-common#35.** This branch is built against unreleased `wallet-common`. Before merging, that PR needs to land, a `v0.5.0-sirosid.13` tag cut, and `package.json` re-pinned from `v0.5.0-sirosid.12`. `package.json` and `yarn.lock` are deliberately **unchanged** here.

## Heads up on the spec version

The rendered profile at fidescommunity.github.io **still serves v4**. This targets the **v5 release text** at `spec/spec.md` on [FIDEScommunity/DIIP `main`](https://github.com/FIDEScommunity/DIIP/blob/main/spec/spec.md) (approved 2026-01-15) — OID4VCI 1.0 Final, OID4VP 1.0 Final, SD-JWT VC draft 13, Token Status List draft 15.

## What's here

**Holder identifiers** — `DID_KEY_VERSION` gains a `"jwk"` option producing `did:jwk`, and **it is now the default** so a wallet is compliant out of the box. The `p256-pub` / `jwk_jcs-pub` did:key versions still work, so wallets already holding credentials bound to a did:key keep functioning — no migration.

**Issuance** — the `jwt` proof carries the holder's `did:jwk` as `iss` and names the key with a `kid` from the DID document instead of embedding a `jwk` header. The Authorization Request now sends `authorization_details` with the `credential_configuration_id` alongside `scope` (both are required of Wallets by the profile; only `scope` was sent before).

**Holder binding** — `cnf.kid` is accepted wherever `cnf.jwk` was, and the KB-JWT names the same verification method rather than re-embedding the key.

**Credential status** — the validity and revocation outcomes surface as `expired`, `notYetValid`, `revoked` or `suspended`, replacing the single `isExpired` flag in the ribbon and mobile banner. `isExpired` is kept in sync for call sites that haven't moved over. New `en.json` keys; the other four locales fall back to English until translated.

## ⚠️ Two regressions this fixes — worth the closest review

Defaulting to did:jwk changes every credential key pair's `kid` from a JWK thumbprint to a DID URL. That silently broke two things, because **mdoc device keys and SD-JWT `cnf.jwk` can only ever produce a thumbprint**:

1. mdoc presentation — `generateDeviceResponse` looked up key pairs strictly by thumbprint
2. SD-JWT presentation whenever an issuer binds by `cnf.jwk` rather than `cnf.kid`

Both now route through `keystore.findKeypairByKid`, which matches on `kid` first and falls back to comparing thumbprints of the stored public keys. This is the part most likely to bite existing wallets, so it has direct test coverage.

## Testing

Suite goes **379 → 389 passing**, including a cross-repo round trip: the keystore mints a `did:jwk`, signs a DIIP-shaped proof, and wallet-common's resolver resolves that DID back to a key that verifies the signature.

The 3 failing test *files* (`QueryableList`, `AddCredentials`, `ScanPhysicalID`) are pre-existing on `release/sirosid` — they fail at import on `localStorage` being undefined in `i18n.js`, unrelated to this branch. Typecheck and lint are byte-identical to baseline (both already red there: 35 errors, 2 warnings). All verified against a worktree of the base commit rather than assumed.

Beyond unit tests: the wallet-frontend Docker image builds against the updated library, and the dev stack runs with `did_key_version: jwk` confirmed in the served config.

**Not verified:** a browser click-through of issuance and presentation. Playwright's Chromium download stalled repeatedly in this environment.